### PR TITLE
tests: Mark pdm-pep517 integration test as fixed

### DIFF
--- a/tests/integration/test_backends.py
+++ b/tests/integration/test_backends.py
@@ -86,10 +86,6 @@ def normalized_name(request):
                 None,
             ),
             "pdm-pep517",
-            marks=pytest.mark.xfail(
-                reason="https://github.com/pdm-project/pdm-pep517/issues/90",
-                strict=True,
-            ),
             id="pdm-pep517",
         ),
         pytest.param(


### PR DESCRIPTION
The issue https://github.com/pdm-project/pdm-pep517/issues/90 has
been fixed and thus, `xfail` marker must be removed.

Fixes: https://github.com/stanislavlevin/pyproject_installer/issues/1