### PR TITLE
installer: Don't populate INSTALLER by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,17 @@ This tool is intended to build wheel from Python source tree and install it.
     fragile, and no RECORD file is better than one that does not correspond to
     reality.
 
-- INSTALLER is populated with `pyproject_installer` as installer by default.<br>
+- INSTALLER file is not installed by default(optional).<br>
   https://peps.python.org/pep-0627/#optional-installer-file:
   > The INSTALLER file is also made optional, and specified to be used for
     informational purposes only. It is still a single-line text file containing
     the name of the installer.
+
+  https://packaging.python.org/en/latest/specifications/recording-installed-packages/#the-installer-file:
+  > This value should be used for informational purposes only. For example, if a
+    tool is asked to uninstall a project but finds no RECORD file, it may
+    suggest that the tool named in INSTALLER may be able to do the
+    uninstallation.
 
 
 ## Usage
@@ -136,7 +142,7 @@ Install options:
 <pre>
 <em><strong>name</strong></em>: --installer INSTALLER
 <em><strong>description</strong></em>: Name of installer to be recorded in dist-info/INSTALLER
-<em><strong>default</strong></em>: pyproject_installer
+<em><strong>default</strong></em>: None, INSTALLER will be omitted
 <em><strong>example</strong></em>: python -m pyproject_installer install --installer custom_installer
 </pre>
 

--- a/src/pyproject_installer/__main__.py
+++ b/src/pyproject_installer/__main__.py
@@ -168,11 +168,10 @@ def main_parser(prog):
     )
     parser_install.add_argument(
         "--installer",
-        default="pyproject_installer",
         type=str,
         help=(
             "Name of installer to be recorded in dist-info/INSTALLER "
-            "(default: pyproject_installer)"
+            "(default: None, INSTALLER will be omitted)"
         ),
     )
     parser_install.add_argument(

--- a/src/pyproject_installer/install_cmd/_install.py
+++ b/src/pyproject_installer/install_cmd/_install.py
@@ -511,7 +511,7 @@ def filter_dist_info(dist_info, members, strip_dist_info=True):
 def install_wheel(
     wheel_path,
     destdir,
-    installer="pyproject_installer",
+    installer=None,
     strip_dist_info=True,
 ):
     wheel_path = validate_wheel_path(wheel_path)
@@ -521,7 +521,6 @@ def install_wheel(
     logger.info("Wheel directory: %s", wheel_path.parent)
     logger.info("Wheel filename: %s", wheel_path.name)
     logger.info("Destination: %s", destdir)
-    logger.info("Installer: %s", installer)
 
     with WheelFile(wheel_path) as whl:
         dist_name = whl.dist_name
@@ -546,9 +545,10 @@ def install_wheel(
             dist_info_path, scheme=scheme, destdir=destdir
         )
 
-    # write installer of this distribution
-    installer_path = dist_info_path / "INSTALLER"
-    installer_path.write_text(f"{installer}\n", encoding="utf-8")
+    if installer is not None:
+        # write installer of this distribution if requested
+        installer_path = dist_info_path / "INSTALLER"
+        installer_path.write_text(f"{installer}\n", encoding="utf-8")
 
     data_path = rootdir / f"{dist_name}-{dist_version}.data"
     if data_path.exists():

--- a/tests/unit/test_install/test_installer.py
+++ b/tests/unit/test_install/test_installer.py
@@ -489,9 +489,7 @@ def test_installer_tool_default(wheel_contents, wheel, installed_wheel):
     dest_wheel = installed_wheel()
     install_wheel(wheel(contents=contents), destdir=dest_wheel.destdir)
 
-    assert (
-        dest_wheel.distinfo / "INSTALLER"
-    ).read_text() == "pyproject_installer\n"
+    assert not (dest_wheel.distinfo / "INSTALLER").exists()
 
 
 def test_installer_tool_custom(wheel_contents, wheel, installed_wheel):
@@ -556,8 +554,6 @@ def test_installation_filelist(
 
         expected_filelist.add(dest_wheel.sitedir / f)
 
-    # written by installer
-    expected_filelist.add(dest_wheel.distinfo / "INSTALLER")
     # console script
     expected_filelist.add(dest_wheel.scripts / "bar")
     assert dest_wheel.filelist() == expected_filelist
@@ -603,8 +599,6 @@ def test_data_scheme_keys(scheme_key, wheel_contents, wheel, installed_wheel):
 
         expected_filelist.add(dest_wheel.sitedir / f)
 
-    # written by installer
-    expected_filelist.add(dest_wheel.distinfo / "INSTALLER")
     assert dest_wheel.filelist() == expected_filelist
 
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -296,7 +296,7 @@ def test_install_cli_default(mocker, mock_install_wheel, mock_read_tracker):
     i_args = (wheel,)
     i_kwargs = {
         "destdir": destdir,
-        "installer": "pyproject_installer",
+        "installer": None,
         "strip_dist_info": True,
     }
 
@@ -315,7 +315,7 @@ def test_install_cli_destdir(mocker, mock_install_wheel, mock_read_tracker):
     i_args = (wheel,)
     i_kwargs = {
         "destdir": destdir,
-        "installer": "pyproject_installer",
+        "installer": None,
         "strip_dist_info": True,
     }
 
@@ -333,7 +333,7 @@ def test_install_cli_wheel(mocker, mock_install_wheel, mock_read_tracker):
     i_args = (wheel,)
     i_kwargs = {
         "destdir": destdir,
-        "installer": "pyproject_installer",
+        "installer": None,
         "strip_dist_info": True,
     }
 
@@ -353,7 +353,7 @@ def test_install_cli_wheel_destdir(
     i_args = (wheel,)
     i_kwargs = {
         "destdir": destdir,
-        "installer": "pyproject_installer",
+        "installer": None,
         "strip_dist_info": True,
     }
 
@@ -390,7 +390,7 @@ def test_install_cli_no_strip_dist_info(mock_install_wheel, mock_read_tracker):
     i_args = (wheel,)
     i_kwargs = {
         "destdir": destdir,
-        "installer": "pyproject_installer",
+        "installer": None,
         "strip_dist_info": False,
     }
 


### PR DESCRIPTION
According to https://peps.python.org/pep-0627/#optional-installer-file:
> The INSTALLER file is also made optional, and specified to be used for
  informational purposes only.
>
> Instead of relying on the installer name, tools should use feature
  detection. The current document offers a crude way of making a project
  untouchable by Python tooling: omitting RECORD file.

and clarified https://packaging.python.org/en/latest/specifications/recording-installed-packages/#the-installer-file:

> This value should be used for informational purposes only. For
  example, if a tool is asked to uninstall a project but finds no RECORD
  file, it may suggest that the tool named in INSTALLER may be able to do
  the uninstallation.

In a big scale of OS(global context of interpreter) there can be hundreds
and thousands of meaningless `INSTALLER`s.

With this change `INSTALLER` is no longer populated with
`pyproject_installer` by default, but omitted instead.

Fixes: https://github.com/stanislavlevin/pyproject_installer/issues/7