### PR TITLE
pylint: Provide ignore paths for Pylint 2.14.4+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,9 @@ recursive = true
 ignore-paths = [
     ".*/_vendor/.*",
     '.*/\.git/.*',
+    '^.git/.*',  # dot escaping doesn't work, see pylint#5398
     '.*/\.tox/.*',
+    '^.tox/.*',  # dot escaping doesn't work, see pylint#5398
 ]
 suggestion-mode = "yes"
 persistent="no"


### PR DESCRIPTION
New pylint 2.14.4 includes fix for https://github.com/PyCQA/pylint/issues/6964, this results in our pylint
configuration for `ignore-paths` is no longer valid (`./.tox` => `.tox`)
and pylint fails on checking not related projects from `.tox` directory:
> ERROR: InvocationError for command /home/runner/work/pyproject_installer/pyproject_installer/.tox/pylint/bin/python -m pylint -v --rcfile=/home/runner/work/pyproject_installer/pyproject_installer/pyproject.toml . (exited with code 30)

Fixes: https://github.com/stanislavlevin/pyproject_installer/issues/11