### PR TITLE
readme: Update examples for passing config settings to setuptools

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,10 @@ one(wheel).
 <em><strong>description</strong></em>: ad-hoc configuration for build backend as dumped JSON dictionary
 <em><strong>default</strong></em>: None
 
-Example of passing <em><strong>config_settings</strong></em> for setuptools backend:
+Example of passing <em><strong>config_settings</strong></em> for setuptools>=64.0.0:
+python -m pyproject_installer build --backend-config-settings='{"--build-option": ["--python-tag=sometag", "--build-number=123"]}'
+
+Example of passing <em><strong>config_settings</strong></em> for setuptools<64.0.0:
 python -m pyproject_installer build --backend-config-settings='{"--global-option": ["--python-tag=sometag", "--build-number=123"]}'
 
 Example of passing <em><strong>config_settings</strong></em> for pdm backend:


### PR DESCRIPTION
As of 64.0.0 `setuptools` deprecated usage of `--global-option`.

https://setuptools.pypa.io/en/latest/history.html#v64-0-0 https://setuptools.pypa.io/en/latest/history.html#deprecations:
> [#3380](https://github.com/pypa/setuptools/issues/3380): Passing some types of parameters via --global-option to setuptools [PEP 517](https://peps.python.org/pep-0517/)/[PEP 660](https://peps.python.org/pep-0660/) backend is now considered deprecated. The user can pass the same arbitrary parameter via --build-option (--global-option is now reserved for flags like --verbose or --quiet).
>
> Both --build-option and --global-option are supported as a transitional effort (a.k.a. “escape hatch”). In the future a proper list of allowed config_settings may be created.

Fixes: https://github.com/stanislavlevin/pyproject_installer/issues/17