### PR TITLE
tests: Follow renaming `pdm-pep517`

### DIFF
--- a/tests/integration/test_backends.py
+++ b/tests/integration/test_backends.py
@@ -81,12 +81,12 @@ def normalized_name(request):
         ),
         pytest.param(
             (
-                "pdm-pep517",
-                "https://github.com/pdm-project/pdm-pep517",
+                "pdm-backend",
+                "https://github.com/pdm-project/pdm-backend",
                 None,
             ),
-            "pdm-pep517",
-            id="pdm-pep517",
+            "pdm-backend",
+            id="pdm-backend",
         ),
         pytest.param(
             (


### PR DESCRIPTION
`pdm-pep517` was renamed `pdm-backend` in:
https://github.com/pdm-project/pdm-backend/commit/3c29971b0774a487ac23949c159ea3149c8e6fa1

Fixes: https://github.com/stanislavlevin/pyproject_installer/issues/19