### PR TITLE
tests: Replace virtualenv with stdlib's venv

### DIFF
--- a/tests/integration/test_backends.py
+++ b/tests/integration/test_backends.py
@@ -107,7 +107,7 @@ def normalized_name(request):
 def test_build_and_install_in_tree_backends(
     virt_env_installer, git_tree, install_build_deps, destdir, normalized_name
 ):
-    python = str(virt_env_installer.exe)
+    python = virt_env_installer.env_exec_cmd
     install_build_deps(python, srcdir=git_tree)
     build_args = [python, "-m", "pyproject_installer", "build"]
     subprocess.check_call(build_args, cwd=git_tree)

--- a/tests/integration/test_buildable.py
+++ b/tests/integration/test_buildable.py
@@ -8,16 +8,29 @@ import subprocess
 from pyproject_installer import __version__ as installer_version
 
 
-def install_pkg(creator, pkg):
+def install_pkg(context, pkg, ignore_installed=True):
     install_args = [
-        str(creator.exe),
+        context.env_exec_cmd,
         "-Im",
         "pip",
         "install",
-        "--ignore-installed",
+    ]
+    if ignore_installed:
+        install_args.append("--ignore-installed")
+    install_args.append(pkg)
+    subprocess.check_call(install_args, cwd=context.env_dir)
+
+
+def upgrade_pkg(context, pkg):
+    install_args = [
+        context.env_exec_cmd,
+        "-Im",
+        "pip",
+        "install",
+        "--upgrade",
         pkg,
     ]
-    subprocess.check_call(install_args, cwd=creator.dest)
+    subprocess.check_call(install_args, cwd=context.env_dir)
 
 
 def test_build_with_build(virt_env, wheeldir):
@@ -26,7 +39,7 @@ def test_build_with_build(virt_env, wheeldir):
     assert cwd.name == "pyproject_installer"
 
     build_args = [
-        str(virt_env.exe),
+        virt_env.env_exec_cmd,
         "-Im",
         "build",
         ".",
@@ -43,12 +56,12 @@ def test_build_with_build(virt_env, wheeldir):
 
 
 def test_build_with_pip(virt_env, wheeldir):
-    install_pkg(virt_env, "pip")
+    upgrade_pkg(virt_env, "pip")
     cwd = Path.cwd()
     assert cwd.name == "pyproject_installer"
 
     build_args = [
-        str(virt_env.exe),
+        virt_env.env_exec_cmd,
         "-Im",
         "pip",
         "wheel",

--- a/tests/integration/test_config_settings.py
+++ b/tests/integration/test_config_settings.py
@@ -6,13 +6,13 @@ def test_config_settings_setuptools(
     virt_env_installer, setuptools_project, install_build_deps, wheeldir
 ):
     """
-    1. Create virtualenv with installed pyproject_installer
+    1. Create virtual environment with installed pyproject_installer
     2. Create pyproject with setuptools build backend
     3. Install build requirements with pip
     4. Build with custom config_settings (today's setuptools respects
        `--global-option` key)
     """
-    python = str(virt_env_installer.exe)
+    python = virt_env_installer.env_exec_cmd
     install_build_deps(python, srcdir=setuptools_project)
     build_args = [
         python,
@@ -44,13 +44,13 @@ def test_config_settings_pdm(
     virt_env_installer, pdm_project, install_build_deps, wheeldir
 ):
     """
-    1. Create virtualenv with installed pyproject_installer
+    1. Create virtual environment with installed pyproject_installer
     2. Create pyproject with pdm build backend
     3. Install build requirements with pip
     4. Build with custom config_settings (today's pdm respects
        `--python-tag`, `--py-limited-api` and `--plat-name` keys
     """
-    python = str(virt_env_installer.exe)
+    python = virt_env_installer.env_exec_cmd
     install_build_deps(python, srcdir=pdm_project)
     build_args = [
         python,

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,6 @@ commands =
 # install deps with pip
 deps =
     pytest
-    virtualenv
 
 description = integration tests
 allowlist_externals =
@@ -77,7 +76,6 @@ description = check the code base with pylint
 deps =
     pylint
     pytest
-    virtualenv
 commands = python -m pylint \
            -v \
            --rcfile={toxinidir}/pyproject.toml \


### PR DESCRIPTION
- it's safer to rely on stdlib's packages
- less dependencies on third-party packages

Fixes: https://github.com/stanislavlevin/pyproject_installer/issues/23