### PR TITLE
tests: Fix wrong assumption about project's dirname

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -13,6 +13,8 @@ except ModuleNotFoundError:
 
 import pytest
 
+from pyproject_installer import __version__ as installer_version
+from pyproject_installer.build_cmd import WHEEL_TRACKER
 from pyproject_installer.build_cmd._build import call_hook
 
 
@@ -34,7 +36,6 @@ class ContextVenv(EnvBuilder):
 @pytest.fixture(scope="session")
 def pyproject_installer_whl():
     """Build pyproject_installer as wheel"""
-    assert Path.cwd().name == "pyproject_installer"
     with tempfile.TemporaryDirectory() as d:
         wheels = Path(d) / "wheels"
         wheels.mkdir()
@@ -47,7 +48,14 @@ def pyproject_installer_whl():
             wheels,
         ]
         subprocess.check_call(build_args)
-        yield wheels / (wheels / ".wheeltracker").read_text().rstrip()
+        built_files = {f.name for f in wheels.iterdir()}
+        # make sure that pyproject_installer was built
+        expected_files = {
+            WHEEL_TRACKER,
+            f"pyproject_installer-{installer_version}-py3-none-any.whl",
+        }
+        assert built_files == expected_files
+        yield wheels / (wheels / WHEEL_TRACKER).read_text().rstrip()
 
 
 @pytest.fixture

--- a/tests/integration/test_buildable.py
+++ b/tests/integration/test_buildable.py
@@ -1,7 +1,6 @@
 """
 Check if pyproject_installer is buildable by other tools like `build` or `pip`
 """
-from pathlib import Path
 import subprocess
 
 
@@ -35,8 +34,6 @@ def upgrade_pkg(context, pkg):
 
 def test_build_with_build(virt_env, wheeldir):
     install_pkg(virt_env, "build")
-    cwd = Path.cwd()
-    assert cwd.name == "pyproject_installer"
 
     build_args = [
         virt_env.env_exec_cmd,
@@ -46,7 +43,7 @@ def test_build_with_build(virt_env, wheeldir):
         "--outdir",
         str(wheeldir),
     ]
-    subprocess.check_call(build_args, cwd=cwd)
+    subprocess.check_call(build_args)
     built_files = {f.name for f in wheeldir.iterdir()}
     expected_files = {
         f"pyproject_installer-{installer_version}-py3-none-any.whl",
@@ -57,8 +54,6 @@ def test_build_with_build(virt_env, wheeldir):
 
 def test_build_with_pip(virt_env, wheeldir):
     upgrade_pkg(virt_env, "pip")
-    cwd = Path.cwd()
-    assert cwd.name == "pyproject_installer"
 
     build_args = [
         virt_env.env_exec_cmd,
@@ -69,7 +64,7 @@ def test_build_with_pip(virt_env, wheeldir):
         "-w",
         str(wheeldir),
     ]
-    subprocess.check_call(build_args, cwd=cwd)
+    subprocess.check_call(build_args)
     built_files = {f.name for f in wheeldir.iterdir()}
     expected_files = {
         f"pyproject_installer-{installer_version}-py3-none-any.whl",


### PR DESCRIPTION
There was wrong assumption that the project's directory name must be `pyproject_installer`. This was done to be sure that `pyproject_installer` was being built (not any other project). But actually dirname can have any name. The crucial thing is checking build's artifacts.

Fixes: https://github.com/stanislavlevin/pyproject_installer/issues/22