### PR TITLE
cli: Provide descriptions for subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # pyproject-installer
 
-This tool is intended to build wheel from Python source tree and install it.
+This tool is intended for build and install of Python project from source
+tree in network-isolated environments.
 
 
 ## Description
@@ -78,6 +79,8 @@ This tool is intended to build wheel from Python source tree and install it.
 ## Usage
 
 ### Build
+Build project from source tree in current Python environment according to
+PEP517. This doesn't trigger installation of project's build dependencies.
 ```
 python -m pyproject_installer build
 ```
@@ -124,6 +127,8 @@ python -m pyproject_installer build --backend-config-settings='{"--python-tag": 
 </pre>
 
 ### Install
+Install project built in wheel format. This doesn't trigger installation of
+project's runtime dependencies.
 ```
 python -m pyproject_installer install
 ```

--- a/src/pyproject_installer/__main__.py
+++ b/src/pyproject_installer/__main__.py
@@ -87,7 +87,10 @@ def convert_config_settings(value):
 
 def main_parser(prog):
     parser = argparse.ArgumentParser(
-        description="Build and install Python project from source tree",
+        description=(
+            "Build and install Python project from source tree in "
+            "network-isolated environments"
+        ),
         prog=prog,
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
@@ -105,13 +108,19 @@ def main_parser(prog):
 
     subparsers = parser.add_subparsers(
         title="subcommands",
-        description="valid subcommands",
         help="--help for additional help",
         required=True,
     )
 
     # build subcli
-    parser_build = subparsers.add_parser("build")
+    parser_build = subparsers.add_parser(
+        "build",
+        description=(
+            "Build project from source tree in current Python environment "
+            "according to PEP517. This doesn't trigger installation of "
+            "project's build dependencies."
+        ),
+    )
     parser_build.add_argument(
         "srcdir",
         type=Path,
@@ -144,7 +153,14 @@ def main_parser(prog):
     parser_build.set_defaults(main=build)
 
     # install subcli
-    parser_install = subparsers.add_parser("install")
+    parser_install = subparsers.add_parser(
+        "install",
+        description=(
+            "Install project built in wheel format. "
+            "This doesn't trigger installation of project's runtime "
+            "dependencies."
+        ),
+    )
     parser_install.add_argument(
         "wheel",
         type=Path,


### PR DESCRIPTION
https://docs.python.org/3/library/argparse.html#description:
> This argument gives a brief description of what the program does and
how it works. In help messages, the description is displayed between the command-line usage string and the help messages for the various arguments