### PR TITLE
wheel: Handle invalid zip files as WheelFileError

### DIFF
--- a/src/pyproject_installer/errors.py
+++ b/src/pyproject_installer/errors.py
@@ -4,3 +4,7 @@ class RunCommandError(Exception):
 
 class RunCommandEnvError(Exception):
     """Venv creation or usage fails"""
+
+
+class WheelFileError(Exception):
+    """Invalid wheel file"""

--- a/src/pyproject_installer/run_cmd/_run_command.py
+++ b/src/pyproject_installer/run_cmd/_run_command.py
@@ -9,6 +9,8 @@ def run_command(wheel, *args, venv_name=".run_venv", **kwargs):
     try:
         run_env = PyprojectVenv(wheel)
         run_env.create(venv_name)
+    except RunCommandEnvError:
+        raise
     except Exception as e:
         raise RunCommandEnvError(str(e)) from e
     return run_env.run(*args, **kwargs)

--- a/tests/unit/test_install/test_installer.py
+++ b/tests/unit/test_install/test_installer.py
@@ -7,6 +7,7 @@ import sysconfig
 
 import pytest
 
+from pyproject_installer.errors import WheelFileError
 from pyproject_installer.install_cmd import install_wheel
 from pyproject_installer.install_cmd._install import (
     get_installation_scheme,
@@ -67,6 +68,15 @@ def test_nonexistent_wheel(installed_wheel):
         install_wheel(
             Path("/nonexistent/wheel.file"), destdir=installed_wheel().destdir
         )
+
+
+def test_bad_wheel(tmpdir, destdir):
+    bad_whl = tmpdir / "wheel.whl"
+    bad_whl.touch(exist_ok=False)
+    with pytest.raises(
+        WheelFileError, match=f"Error reading wheel {bad_whl}: "
+    ):
+        install_wheel(bad_whl, destdir=destdir)
 
 
 @pytest.mark.skipif(os.geteuid() == 0, reason="Requires unprivileged user")


### PR DESCRIPTION
- reraise BadZipFile as WheelFileError
- don't try to close bad wheel file
    
Fixes: https://github.com/stanislavlevin/pyproject_installer/issues/27