### PR TITLE
tests: Restore cwd before removing a tree

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,6 +106,8 @@ class WheelContents(MutableMapping):
 @pytest.fixture
 def tmpdir(tmp_path):
     yield tmp_path
+    # Solaris: rmtree can't remove current working directory
+    assert Path.cwd() != tmp_path
     shutil.rmtree(tmp_path)
 
 

--- a/tests/unit/test_build/test_builder.py
+++ b/tests/unit/test_build/test_builder.py
@@ -121,7 +121,7 @@ def test_verbosity(mock_build, pyproject, build_args):
     mock_build.assert_called_once_with(**b_kwargs)
 
 
-def test_paths_resolved(monkeypatch, mock_build, pyproject):
+def test_paths_resolved(mock_build, pyproject, monkeypatch):
     """Check if srcdir and wheeldir are resolved for backend"""
     pyproject_path = pyproject()
     cwd = pyproject_path.parent


### PR DESCRIPTION
The fixture `tmpdir` cleans up temp files/dirs on teardown. `test_paths_resolved` in turn uses fixture `monkeypatch` for patching cwd (it's changed to `tmpdir`). `monkeypatch` restores back its changes on teardown. But the teardown of `tmpdir` occurs earlier and this triggers removal error on Solaris where `rmdir` can't remove current working directory.
https://docs.oracle.com/cd/E88353_01/html/E37841/rmdir-2.html:
> EINVAL
  The directory to be removed is the current directory, or the final
  component of path is “.”.

So, the order of Pytest's fixtures was incorrect:
```
tests/unit/test_build/test_builder.py::test_paths_resolved
SETUP    S pytestconfig
SETUP    S tmp_path_factory
        SETUP    F monkeypatch
        SETUP    F mocker (fixtures used: pytestconfig)
        SETUP    F mock_build (fixtures used: mocker)
        SETUP    F tmp_path (fixtures used: tmp_path_factory)
        SETUP    F tmpdir (fixtures used: tmp_path)
        SETUP    F pyproject (fixtures used: tmpdir)
        tests/unit/test_build/test_builder.py::test_paths_resolved (fixtures used: mock_build, mocker, monkeypatch, pyproject, pytestconfig, request, tmp_path, tmp_path_factory, tmpdir)
        TEARDOWN F pyproject
        TEARDOWN F tmpdir
        TEARDOWN F tmp_path
        TEARDOWN F mock_build
        TEARDOWN F mocker
        TEARDOWN F monkeypatch
TEARDOWN S tmp_path_factory
TEARDOWN S pytestconfig
```

Fixes: https://github.com/stanislavlevin/pyproject_installer/issues/33