### PR TITLE
deps: Add support for pdm dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Positional arguments:
 
 <pre>
 <em><strong>name</strong></em>: add
-<em><strong>description</strong></em>: configure source of Python dependencies. Supported sources: standardized formats like PEP517, PEP518 or core metadata are fully supported, while tool-specific formats like pip, tox, poetry or hatch have limited support.
+<em><strong>description</strong></em>: configure source of Python dependencies. Supported sources: standardized formats like PEP517, PEP518 or core metadata are fully supported, while tool-specific formats like pip, tox, poetry, hatch or pdm have limited support.
 <em><strong>example</strong></em>: python -m pyproject_installer deps add --help
 </pre>
 
@@ -250,7 +250,7 @@ Positional arguments:
 
 <pre>
 <em><strong>description</strong></em>: source type
-<em><strong>choice</strong></em>: pep517, pep518, metadata, pip_reqfile, poetry, tox, hatch
+<em><strong>choice</strong></em>: pep517, pep518, metadata, pip_reqfile, poetry, tox, hatch, pdm
 </pre>
 
 <pre>
@@ -280,6 +280,9 @@ python -m pyproject_installer deps add check poetry dev
 
 Configuration of source of <strong>hatch</strong> requirements:
 python -m pyproject_installer deps add check hatch hatch.toml test
+
+Configuration of source of <strong>pdm</strong> requirements:
+python -m pyproject_installer deps add check pdm test
 </pre>
 
 ---

--- a/src/pyproject_installer/deps_cmd/collectors/__init__.py
+++ b/src/pyproject_installer/deps_cmd/collectors/__init__.py
@@ -5,6 +5,7 @@ from .metadata import MetadataCollector
 from .poetry import PoetryCollector
 from .tox import ToxCollector
 from .hatch import HatchCollector
+from .pdm import PdmCollector
 
 
 __all__ = ["get_collector", "SUPPORTED_COLLECTORS"]
@@ -19,6 +20,7 @@ SUPPORTED_COLLECTORS = {
         PoetryCollector,
         ToxCollector,
         HatchCollector,
+        PdmCollector,
     ]
 }
 

--- a/src/pyproject_installer/deps_cmd/collectors/pdm.py
+++ b/src/pyproject_installer/deps_cmd/collectors/pdm.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+from .collector import Collector
+from ...lib import requirements
+from ...lib import tomllib
+
+
+class PdmCollector(Collector):
+    """Parses pdm's dependencies from its configuration
+
+    Specification:
+    - https://pdm.fming.dev/latest/usage/dependency/#add-development-only-dependencies
+
+    Limitations:
+    - supported only PEP508 requirements
+    """
+
+    name = "pdm"
+
+    def __init__(self, group):
+        self.group = group
+
+    def collect(self):
+        pyproject_file = Path.cwd() / "pyproject.toml"
+
+        with pyproject_file.open("rb") as f:
+            pyproject_data = tomllib.load(f)
+
+        try:
+            deps_data = pyproject_data["tool"]["pdm"]["dev-dependencies"]
+        except KeyError:
+            raise ValueError(
+                "Pdm: missing tool.pdm.dev-dependencies table in "
+                f"{pyproject_file.name}"
+            ) from None
+
+        try:
+            deps = deps_data[self.group]
+        except KeyError:
+            raise ValueError(
+                f"Pdm dependencies are not configured for group: {self.group}"
+            ) from None
+
+        for line in deps:
+            line = line.strip()
+            try:
+                requirements.Requirement(line)
+            except requirements.InvalidRequirement:
+                continue
+            else:
+                yield line

--- a/tests/unit/test_deps/test_collectors.py
+++ b/tests/unit/test_deps/test_collectors.py
@@ -146,6 +146,25 @@ def hatch_deps(tmpdir, monkeypatch):
     return _hatch_deps
 
 
+@pytest.fixture
+def pdm_deps(tmpdir, monkeypatch):
+    """pdm deps"""
+
+    def _pdm_deps(group, deps):
+        contents = ["[tool.pdm.dev-dependencies]"]
+        if deps is not None:
+            contents.append(f"{group} = [")
+            contents.extend((f'"{x}",' for x in deps))
+            contents.append("]")
+
+        config_path = tmpdir / "pyproject.toml"
+        config_path.write_text("\n".join(contents) + "\n", encoding="utf-8")
+        monkeypatch.chdir(tmpdir)
+        return config_path
+
+    return _pdm_deps
+
+
 PEP508_DEPS_DATA = (
     ([], []),
     (["foo"], ["foo"]),
@@ -862,6 +881,99 @@ def test_hatch_collector_missing_deps(config, hatch_deps, depsconfig):
         f"Hatch dependencies are not configured for {hatchenv}: "
         f"missing {hatchenv}.dependencies and {hatchenv}.extra-dependencies"
     )
+    assert str(exc.value) == expected_err
+
+    actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))
+    assert actual_conf == input_conf
+
+
+@pytest.mark.parametrize("deps_data", PEP508_DEPS_DATA)
+def test_pdm_collector_deps(deps_data, pdm_deps, depsconfig):
+    """Collection of pdm dependencies"""
+    # prepare source config
+    srcname = "foo"
+    collector = "pdm"
+    group = "test"
+
+    in_reqs, out_reqs = deps_data
+
+    pdm_deps(group, in_reqs)
+    input_conf = {
+        "sources": {
+            srcname: {
+                "srctype": collector,
+                "srcargs": [group],
+            },
+        }
+    }
+    depsconfig_path = depsconfig(json.dumps(input_conf))
+
+    deps_command("sync", depsconfig_path, srcnames=[])
+
+    expected_conf = deepcopy(input_conf)
+    if out_reqs:
+        expected_conf["sources"][srcname]["deps"] = out_reqs
+    actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))
+    assert actual_conf == expected_conf
+
+
+@pytest.mark.parametrize("pdm_config", ("", "[tool]", "[tool.pdm]"))
+def test_pdm_collector_missing_configuration(
+    pdm_config, tmpdir, depsconfig, monkeypatch
+):
+    """Collection of pdm with missing configuration"""
+    # prepare source config
+    srcname = "foo"
+    collector = "pdm"
+    group = "test"
+
+    pdm_config_path = tmpdir / "pyproject.toml"
+    pdm_config_path.write_text(pdm_config + "\n", encoding="utf-8")
+    input_conf = {
+        "sources": {
+            srcname: {
+                "srctype": collector,
+                "srcargs": [group],
+            },
+        }
+    }
+    depsconfig_path = depsconfig(json.dumps(input_conf))
+
+    monkeypatch.chdir(tmpdir)
+    with pytest.raises(ValueError) as exc:
+        deps_command("sync", depsconfig_path, srcnames=[])
+    expected_err = (
+        "Pdm: missing tool.pdm.dev-dependencies table in "
+        f"{pdm_config_path.name}"
+    )
+    assert str(exc.value) == expected_err
+
+    actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))
+    assert actual_conf == input_conf
+
+
+def test_pdm_collector_missing_deps(pdm_deps, depsconfig):
+    """Collection of missing pdm deps"""
+    # prepare source config
+    srcname = "foo"
+    collector = "pdm"
+    group = "test"
+
+    pdm_deps(group, deps=None)
+
+    input_conf = {
+        "sources": {
+            srcname: {
+                "srctype": collector,
+                "srcargs": [group],
+            },
+        }
+    }
+    depsconfig_path = depsconfig(json.dumps(input_conf))
+
+    with pytest.raises(ValueError) as exc:
+        deps_command("sync", depsconfig_path, srcnames=[])
+    expected_err = f"Pdm dependencies are not configured for group: {group}"
     assert str(exc.value) == expected_err
 
     actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))


### PR DESCRIPTION
Specification:
https://pdm.fming.dev/latest/usage/dependency/#add-development-only-dependencies

Fixes: https://github.com/stanislavlevin/pyproject_installer/issues/47