### PR TITLE
tests: Replace no longer supported build-option passed as global-option

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -137,7 +137,7 @@ def setuptools_project(pyproject):
         textwrap.dedent(
             """\
             [build-system]
-            requires = ["setuptools"]
+            requires = ["setuptools>=64"]
             build-backend = "setuptools.build_meta"
             """
         )

--- a/tests/integration/test_config_settings.py
+++ b/tests/integration/test_config_settings.py
@@ -10,7 +10,7 @@ def test_config_settings_setuptools(
     2. Create pyproject with setuptools build backend
     3. Install build requirements with pip
     4. Build with custom config_settings (today's setuptools respects
-       `--global-option` key)
+       `--build-option` key)
     """
     python = virt_env_installer.env_exec_cmd
     install_build_deps(python, srcdir=setuptools_project)
@@ -22,7 +22,7 @@ def test_config_settings_setuptools(
         "--backend-config-settings",
         json.dumps(
             {
-                "--global-option": [
+                "--build-option": [
                     "--python-tag=test_tag",
                     "--build-number=123",
                     "--plat-name=test_plat",


### PR DESCRIPTION
It was deprecated as of 64.0.0 `setuptools`:

https://setuptools.pypa.io/en/latest/history.html#v64-0-0
> #3380: Passing some types of parameters via --global-option to
  setuptools PEP 517/PEP 660 backend is now considered deprecated. The
  user can pass the same arbitrary parameter via --build-option
  (--global-option is now reserved for flags like --verbose or --quiet).

And was removed in 69.0.0:
https://setuptools.pypa.io/en/stable/history.html#v69-0-0
> Passing config_settings to setuptools.build_meta with deprecated
  values for --global-option is no longer allowed. (#4066)

Fixes: https://github.com/stanislavlevin/pyproject_installer/issues/59