### PR TITLE
Drop support for system or user installed packaging

### DIFF
--- a/src/pyproject_installer/lib/__init__.py
+++ b/src/pyproject_installer/lib/__init__.py
@@ -4,7 +4,4 @@ try:
 except ModuleNotFoundError:
     from .._vendor import tomli as tomllib
 
-try:
-    from packaging import requirements, markers, specifiers
-except ImportError:
-    from .._vendor.packaging import requirements, markers, specifiers
+from .._vendor.packaging import requirements, markers, specifiers


### PR DESCRIPTION
As of now, system or user installed packaging is imported first. This was made to make it possible for distributions to debundle packaging from this project. But in practice, it can lead to unpredictable results and can't be properly supported.

`pyproject-installer` is supposed to not have any external dependencies and should bring everything it needs inside itself (bundle).

Fixes: https://github.com/stanislavlevin/pyproject_installer/issues/62