### PR TITLE
installer: Make all data/scripts files executable

### DIFF
--- a/src/pyproject_installer/install_cmd/_install.py
+++ b/src/pyproject_installer/install_cmd/_install.py
@@ -68,11 +68,11 @@ def install_wheel_data(data_path, scheme, destdir):
             # point to the correct interpreter.
             for s in f.iterdir():
                 if s.is_file() and not s.is_symlink():
+                    script_path = rootdir / s.name
                     with s.open(mode="rb") as sf:
                         if sf.read(len(MAGIC_SHEBANG)) == MAGIC_SHEBANG:
                             sf.seek(0)
                             sf.readline()  # discard shebang
-                            script_path = rootdir / s.name
                             with script_path.open(mode="wb") as fsf:
                                 fsf.write(
                                     (
@@ -80,9 +80,9 @@ def install_wheel_data(data_path, scheme, destdir):
                                     ).encode("utf-8")
                                 )
                                 shutil.copyfileobj(sf, fsf)
-                            script_path.chmod(
-                                script_path.stat().st_mode | 0o555
-                            )
+                    # make any file in scripts directory executable
+                    # (can be a compiled binary for example)
+                    script_path.chmod(script_path.stat().st_mode | 0o555)
 
         shutil.rmtree(data_path / f)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,7 +60,10 @@ class WheelContents(MutableMapping):
                 (
                     f,
                     "sha256={}".format(
-                        digest_for_record("sha256", v.encode("utf8"))
+                        digest_for_record(
+                            "sha256",
+                            v if isinstance(v, bytes) else v.encode("utf8"),
+                        )
                     ),
                     0,
                 )


### PR DESCRIPTION
Today's Python packaging specification is not clear about making binaries executable on installation from data/scripts/ directory: https://packaging.python.org/en/latest/specifications/binary-distribution-format/

> In wheel, scripts are packaged in
  {distribution}-{version}.data/scripts/. If the first line of a file in
  scripts/ starts with exactly b'#!python', rewrite to point to the
  correct interpreter. Unix installers may need to add the +x bit to these
  files if the archive was created on Windows.

ZipFile in turn, doesn't preserve file permissions in Python: https://github.com/python/cpython/issues/59999

This leads to situation when freshly installed binaries can't be executed.

Fixes: https://github.com/stanislavlevin/pyproject_installer/issues/66