### PR TITLE
pylint: delint against pylint 3.2.0

### DIFF
--- a/tests/unit/test_run/test_env.py
+++ b/tests/unit/test_run/test_env.py
@@ -511,6 +511,9 @@ def test_env_console_script(
     into venv then console scripts of the package from those locations
     will be ignored.
     """
+    # wheel that will be installed into venv on command's run
+    vsp_wheel = None
+
     for ps, data in console_scripts_data.items():
         if data["install"]:
             if data["external_install"]:
@@ -524,6 +527,9 @@ def test_env_console_script(
             # wheel without console script will be installed into venv on
             # command's run
             vsp_wheel = wheel_no_csript("bar")
+
+    # should be guaranteed by tests configuration
+    assert vsp_wheel is not None
 
     expected_passes = [
         console_scripts_data[ps]


### PR DESCRIPTION
Fixes errors found by recent Pylint's 3.2.0:
```
python -m pylint -v --rcfile=pyproject.toml .
Using config file pyproject.toml
************* Module tests.unit.test_run.test_env
tests/unit/test_run/test_env.py:542:12: E0601: Using variable 'vsp_wheel' before assignment (used-before-assignment)

----------------------------------------------------------------------
Your code has been rated at 9.99/10
Checked 64 files, skipped 48 files

Error: Process completed with exit code 2.
```