### PR TITLE
tests: unxfail enscons backend test

### DIFF
--- a/tests/integration/test_backends.py
+++ b/tests/integration/test_backends.py
@@ -95,10 +95,6 @@ def normalized_name(request):
                 None,
             ),
             "enscons",
-            marks=pytest.mark.xfail(
-                reason="https://github.com/dholth/enscons/issues/25",
-                strict=True,
-            ),
             id="enscons",
         ),
     ),


### PR DESCRIPTION
There were several issues with this backend, but
all of them have been fixed recently and the test started to pass:

```
=================================== FAILURES ===================================
_______________ test_build_and_install_in_tree_backends[enscons] _______________
[XPASS(strict)] https://github.com/dholth/enscons/issues/25
```