### PR TITLE
deps: require valid PEP508 Dependency Specifiers for standardized formats (PEP517, PEP518 and core metadata)

### DIFF
--- a/src/pyproject_installer/deps_cmd/collectors/metadata.py
+++ b/src/pyproject_installer/deps_cmd/collectors/metadata.py
@@ -32,7 +32,9 @@ class MetadataCollector(Collector):
         for req in requires:
             try:
                 requirements.Requirement(req)
-            except requirements.InvalidRequirement:
-                continue
-            else:
-                yield req
+            except requirements.InvalidRequirement as e:
+                err_msg = (
+                    f"{self.name}: invalid PEP508 Dependency Specifier: {e}"
+                )
+                raise ValueError(err_msg) from None
+            yield req

--- a/src/pyproject_installer/deps_cmd/collectors/pep517.py
+++ b/src/pyproject_installer/deps_cmd/collectors/pep517.py
@@ -25,7 +25,9 @@ class Pep517Collector(Collector):
         )["result"]:
             try:
                 requirements.Requirement(req)
-            except requirements.InvalidRequirement:
-                continue
-            else:
-                yield req
+            except requirements.InvalidRequirement as e:
+                err_msg = (
+                    f"{self.name}: invalid PEP508 Dependency Specifier: {e}"
+                )
+                raise ValueError(err_msg) from None
+            yield req

--- a/src/pyproject_installer/deps_cmd/collectors/pep518.py
+++ b/src/pyproject_installer/deps_cmd/collectors/pep518.py
@@ -20,7 +20,9 @@ class Pep518Collector(Collector):
         for req in build_system["requires"]:
             try:
                 requirements.Requirement(req)
-            except requirements.InvalidRequirement:
-                continue
-            else:
-                yield req
+            except requirements.InvalidRequirement as e:
+                err_msg = (
+                    f"{self.name}: invalid PEP508 Dependency Specifier: {e}"
+                )
+                raise ValueError(err_msg) from None
+            yield req

--- a/tests/unit/test_deps/test_collectors/test_metadata.py
+++ b/tests/unit/test_deps/test_collectors/test_metadata.py
@@ -1,6 +1,8 @@
 from copy import deepcopy
 import json
 
+import pytest
+
 from pyproject_installer.deps_cmd import deps_command
 
 
@@ -44,18 +46,19 @@ def test_metadata_collector_metadata_invalid_deps(
     input_conf = {"sources": {srcname: {"srctype": collector}}}
     depsconfig_path = depsconfig(json.dumps(input_conf))
 
-    in_reqs, out_reqs = invalid_pep508_data
+    in_reqs, _ = invalid_pep508_data
 
     # configure pyproject with build backend
     pyproject_metadata(reqs=in_reqs)
 
-    deps_command("sync", depsconfig_path, srcnames=[])
+    with pytest.raises(ValueError) as exc:
+        deps_command("sync", depsconfig_path, srcnames=[])
 
-    expected_conf = deepcopy(input_conf)
-    if out_reqs:
-        expected_conf["sources"][srcname]["deps"] = out_reqs
+    expected_err = f"{collector}: invalid PEP508 Dependency Specifier: "
+    assert str(exc.value).startswith(expected_err)
+
     actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))
-    assert actual_conf == expected_conf
+    assert actual_conf == input_conf
 
 
 def test_metadata_collector_wheel_valid_deps(
@@ -98,15 +101,16 @@ def test_metadata_collector_wheel_invalid_deps(
     input_conf = {"sources": {srcname: {"srctype": collector}}}
     depsconfig_path = depsconfig(json.dumps(input_conf))
 
-    in_reqs, out_reqs = invalid_pep508_data
+    in_reqs, _ = invalid_pep508_data
 
     # configure pyproject with build backend
     pyproject_metadata_wheel(reqs=in_reqs)
 
-    deps_command("sync", depsconfig_path, srcnames=[])
+    with pytest.raises(ValueError) as exc:
+        deps_command("sync", depsconfig_path, srcnames=[])
 
-    expected_conf = deepcopy(input_conf)
-    if out_reqs:
-        expected_conf["sources"][srcname]["deps"] = out_reqs
+    expected_err = f"{collector}: invalid PEP508 Dependency Specifier: "
+    assert str(exc.value).startswith(expected_err)
+
     actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))
-    assert actual_conf == expected_conf
+    assert actual_conf == input_conf

--- a/tests/unit/test_deps/test_collectors/test_pep517.py
+++ b/tests/unit/test_deps/test_collectors/test_pep517.py
@@ -57,18 +57,19 @@ def test_pep517_collector_invalid_deps(
     input_conf = {"sources": {srcname: {"srctype": collector}}}
     depsconfig_path = depsconfig(json.dumps(input_conf))
 
-    in_reqs, out_reqs = invalid_pep508_data
+    in_reqs, _ = invalid_pep508_data
 
     # configure pyproject with build backend
     pyproject_pep517_wheel(in_reqs)
 
-    deps_command("sync", depsconfig_path, srcnames=[])
+    with pytest.raises(ValueError) as exc:
+        deps_command("sync", depsconfig_path, srcnames=[])
 
-    expected_conf = deepcopy(input_conf)
-    if out_reqs:
-        expected_conf["sources"][srcname]["deps"] = out_reqs
+    expected_err = f"{collector}: invalid PEP508 Dependency Specifier: "
+    assert str(exc.value).startswith(expected_err)
+
     actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))
-    assert actual_conf == expected_conf
+    assert actual_conf == input_conf
 
 
 def test_pep517_collector_missing_hook(pyproject_with_backend, depsconfig):

--- a/tests/unit/test_deps/test_collectors/test_pep518.py
+++ b/tests/unit/test_deps/test_collectors/test_pep518.py
@@ -100,13 +100,15 @@ def test_pep518_collector_invalid_deps(
     input_conf = {"sources": {srcname: {"srctype": collector}}}
     depsconfig_path = depsconfig(json.dumps(input_conf))
 
-    in_reqs, out_reqs = invalid_pep508_data
+    in_reqs, _ = invalid_pep508_data
 
     pyproject_pep518(in_reqs)
-    deps_command("sync", depsconfig_path, srcnames=[])
 
-    expected_conf = deepcopy(input_conf)
-    if out_reqs:
-        expected_conf["sources"][srcname]["deps"] = out_reqs
+    with pytest.raises(ValueError) as exc:
+        deps_command("sync", depsconfig_path, srcnames=[])
+
+    expected_err = f"{collector}: invalid PEP508 Dependency Specifier: "
+    assert str(exc.value).startswith(expected_err)
+
     actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))
-    assert actual_conf == expected_conf
+    assert actual_conf == input_conf


### PR DESCRIPTION
According to specifications a list of strings must contain `PEP 508` dependency specifiers.

See for details:
https://peps.python.org/pep-0517/#get-requires-for-build-wheel
https://peps.python.org/pep-0518/#build-system-table
https://packaging.python.org/en/latest/specifications/core-metadata/#requires-dist-multiple-use

Fixes: https://github.com/stanislavlevin/pyproject_installer/issues/86