### PR TITLE
deps: pep518: don't require wheel for default build system

### DIFF
--- a/src/pyproject_installer/lib/build_backend.py
+++ b/src/pyproject_installer/lib/build_backend.py
@@ -64,7 +64,7 @@ def parse_build_system_spec(srcdir):
     pyproject_file = srcdir / "pyproject.toml"
     default_build_system = {
         "build-backend": "setuptools.build_meta:__legacy__",
-        "requires": ["setuptools", "wheel"],
+        "requires": ["setuptools"],
     }
 
     if not pyproject_file.is_file():

--- a/tests/unit/test_deps/test_collectors/test_pep518.py
+++ b/tests/unit/test_deps/test_collectors/test_pep518.py
@@ -42,7 +42,7 @@ def test_pep518_collector_missing_pyproject_toml(
     deps_command("sync", depsconfig_path, srcnames=[])
 
     expected_conf = deepcopy(input_conf)
-    expected_conf["sources"][srcname]["deps"] = ["setuptools", "wheel"]
+    expected_conf["sources"][srcname]["deps"] = ["setuptools"]
     actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))
     assert actual_conf == expected_conf
 
@@ -63,7 +63,7 @@ def test_pep518_collector_missing_build_system(
     deps_command("sync", depsconfig_path, srcnames=[])
 
     expected_conf = deepcopy(input_conf)
-    expected_conf["sources"][srcname]["deps"] = ["setuptools", "wheel"]
+    expected_conf["sources"][srcname]["deps"] = ["setuptools"]
     actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))
     assert actual_conf == expected_conf
 


### PR DESCRIPTION
According to updated `PEP518` specification:

> An example [build-system] table for a project built with setuptools is:
  ```toml
  [build-system]
  # Minimum requirements for the build system to execute.
  requires = ["setuptools"]
  ```
> Build tools are expected to use the example configuration file above
  as their default semantics when a pyproject.toml file is not present.

`wheel` is `setuptools`' `PEP517` dependency (required to build a wheel).

See for details:
https://packaging.python.org/en/latest/specifications/pyproject-toml/#declaring-build-system-dependencies-the-build-system-table

Fixes: https://github.com/stanislavlevin/pyproject_installer/issues/87