### PR TITLE
tests: adapt expected argparse printed choices

### DIFF
--- a/tests/unit/test_build/test_backend_caller.py
+++ b/tests/unit/test_build/test_backend_caller.py
@@ -129,15 +129,21 @@ def test_invalid_hook_choice():
         args=[sys.executable, "-m", BACKEND_CALLER_MOD, "be", invalid_hook],
         capture_output=True,
     )
-    expected_err_msg = (
-        "argument hook_name: invalid choice: '{}' (choose from {})\n"
-    ).format(
-        invalid_hook,
-        ", ".join([f"{x!r}" for x in backend_caller.SUPPORTED_HOOKS]),
+    expected_err_msgs = (
+        f"invalid choice: '{invalid_hook}' (choose from {msg})\n"
+        for msg in [
+            # Python 3.12.8/3.13.1+
+            ", ".join(backend_caller.SUPPORTED_HOOKS),
+            # Python < 3.12.8/3.13.1
+            ", ".join(f"'{x}'" for x in backend_caller.SUPPORTED_HOOKS),
+        ]
     )
-
     assert result.returncode
-    assert expected_err_msg.encode("utf-8") in result.stderr
+    assert any(
+        True
+        for msg in expected_err_msgs
+        if msg.encode("utf-8") in result.stderr
+    )
     assert result.stdout == b""
 
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1106,15 +1106,18 @@ def test_deps_cli_add_wrong_srctype(mock_deps_command, capsys):
         project_main.main(deps_args)
     assert exc.value.code == ExitCodes.WRONG_USAGE
 
-    supported_types_msg = ", ".join(
-        f"'{x}'" for x in project_main.SUPPORTED_COLLECTORS
-    )
-    expected_err_msg = (
-        f"invalid choice: '{srctype}' (choose from {supported_types_msg})"
+    expected_err_msgs = (
+        f"invalid choice: '{srctype}' (choose from {msg})\n"
+        for msg in [
+            # Python 3.12.8/3.13.1+
+            ", ".join(project_main.SUPPORTED_COLLECTORS),
+            # Python < 3.12.8/3.13.1
+            ", ".join(f"'{x}'" for x in project_main.SUPPORTED_COLLECTORS),
+        ]
     )
     captured = capsys.readouterr()
     assert not captured.out
-    assert expected_err_msg in captured.err
+    assert any(True for msg in expected_err_msgs if msg in captured.err)
 
 
 @pytest.mark.parametrize("srcargs", (["foo"], ["foo", "bar"]))


### PR DESCRIPTION
Python 3.12.8/3.13.1 changed argparse printed choices.

https://docs.python.org/release/3.12.8/whatsnew/changelog.html#python-3-12-8
> gh-117766: Always use str() to print choices in argparse.

Fixes: https://github.com/stanislavlevin/pyproject_installer/issues/96