### PR TITLE
tests: pull setuptools incorporating support for bdist_wheel

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -133,7 +133,7 @@ def setuptools_project(pyproject):
         textwrap.dedent(
             """\
             [build-system]
-            requires = ["setuptools>=64"]
+            requires = ["setuptools>=70.1.0"]
             build-backend = "setuptools.build_meta"
             """
         )


### PR DESCRIPTION
wheel 0.46.0 (https://wheel.readthedocs.io/en/stable/news.html):
> Removed the bdist_wheel setuptools command implementation and entry
  point. The wheel.bdist_wheel module is now just an alias to
  setuptools.command.bdist_wheel, emitting a deprecation warning on
  import.

In the meantime:
setuptools 70.1.0 (https://setuptools.pypa.io/en/stable/history.html#v70-1-0)
> Adopted the bdist_wheel command from the wheel project

Thereby, setuptools must be >=70.1.0 to not depend on 'wheel' package.

Fixes: https://github.com/stanislavlevin/pyproject_installer/issues/98