### PR TITLE
testing: explicitly list tests dependencies

### DIFF
--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -45,11 +45,7 @@ jobs:
       run: |
         python --version
         python -m pip install --upgrade pip
-        python -m pip install \
-          pylint \
-          black \
-          pytest \
-
+        python -m pip install --group lint
     - name: Pylint
       run: |
         python -m pylint -v --rcfile=pyproject.toml .
@@ -75,11 +71,7 @@ jobs:
       run: |
         python --version
         python -m pip install --upgrade pip
-        python -m pip install \
-          pytest \
-          pytest-mock \
-          pytest-cov \
-
+        python -m pip install --group coverage
         python -m pip install .
 
     - name: Unit tests with coverage
@@ -105,10 +97,7 @@ jobs:
       run: |
         python --version
         python -m pip install --upgrade pip
-        python -m pip install \
-          pytest \
-          pytest-mock \
-
+        python -m pip install --group test
         python -m pip install .
 
     - name: Unit tests with self run
@@ -133,7 +122,7 @@ jobs:
       run: |
         python --version
         python -m pip install --upgrade pip
-        python -m pip install pytest
+        python -m pip install --group test
         python -m pip install .
 
     - name: integration tests

--- a/README.md
+++ b/README.md
@@ -415,6 +415,10 @@ python -m pyproject_installer install --destdir=/rootdir
 ```
 
 ## Tests
+- install tests dependencies (requires `pip 25.1+`):
+  ```
+  python -m pip install --group test
+  ```
 - unit tests can be run as:
   ```
   pytest tests/unit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,21 @@ requires = []
 build-backend = "backend"
 backend-path = ["."]
 
+[dependency-groups]
+test = [
+    "pytest",
+    "pytest-mock",
+]
+coverage = [
+    "pytest-cov",
+    {include-group = "test"},
+]
+lint = [
+    "black",
+    "pylint",
+    {include-group = "test"},
+]
+
 [tool.pyproject_installer.backend]
 package_dir = "src"
 version_file = "src/pyproject_installer/version.py"


### PR DESCRIPTION
Make use of standardized format of dependency groups to specify tests dependencies.

See for details:
https://packaging.python.org/en/latest/specifications/dependency-groups/

Fixes: https://github.com/stanislavlevin/pyproject_installer/issues/106