### PR TITLE
feat(cli): add support for -C change-dir option

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,20 @@
 
 ## Usage
 
+### Global options
+
+These options are accepted by the top-level command and must appear
+**before** the subcommand token.
+
+> **`-C DIR`**
+> Change to `DIR` before running the subcommand. Matches the semantics
+> of `make -C`, `git -C`, and `tar -C`: after the flag takes effect,
+> defaults such as `{cwd}/dist` and `{cwd}/pyproject_deps.json`
+> resolve against the new directory.
+> *Default:* current working directory (no change)
+> Empty `DIR` (e.g. `-C ""`) is treated the same as omitting the flag.
+> *Example:* `python -m pyproject_installer -C /path/to/project build`
+
 ### Build
 
 Build project from source tree in current Python environment according to

--- a/docs/designs/change_dir_option.md
+++ b/docs/designs/change_dir_option.md
@@ -1,0 +1,179 @@
+## Abstract
+This RFE proposes a global `-C <dir>` option that changes the working
+directory before dispatching any subcommand. It matches the semantics of
+`make -C`, `git -C`, and `tar -C`: a true `chdir` performed once, early in
+`main()`.
+
+## Motivation
+Every existing subcommand derives at least one default path from
+`Path.cwd()`:
+- `build` takes `srcdir` from cwd.
+- `install` / `run` look up the wheel via `{cwd}/dist/<WHEEL_TRACKER>`.
+- `deps` reads `{cwd}/<DEFAULT_CONFIG_NAME>` and each collector calls
+  `Path.cwd()` at runtime.
+
+Today, operating on a project that isn't the shell's current directory
+requires wrapping every invocation with `cd <dir> && python -m
+pyproject_installer ...` (and restoring cwd afterwards). RPM specs and
+other packaging macros frequently know the source tree absolute path up
+front; passing it as a flag is more ergonomic than composing a shell
+sequence, and it removes the need for callers to manage cwd state.
+
+A single top-level option keeps the surface small: one flag replaces
+four per-subcommand variants, and every future subcommand inherits the
+behaviour for free.
+
+## Specification
+
+### User-facing contract
+- Syntax: `python -m pyproject_installer -C <dir> <subcommand> [args...]`.
+- `-C` is declared on the top-level `MainArgumentParser`, so it must
+  appear **before** the subcommand token. There is no long alias and no
+  per-subcommand variant.
+- `<dir>` must be a directory that exists and is accessible. Failures
+  produce the standard argparse error path (usage line on stderr, exit
+  code 2). If `<dir>` is present but empty (e.g. `-C ""`), the current
+  working directory is left unchanged.
+- The flag is a true `chdir`: after the option is applied, the process
+  cwd is `<dir>`. Relative paths passed elsewhere on the same command
+  line (for example, `-C ../pkg install dist/foo.whl`) resolve against
+  the new cwd (`../pkg/dist/foo.whl`). Relative paths passed as the
+  `-C` value itself resolve against the original cwd (standard argparse
+  behaviour: the tool only sees the string the shell produced).
+- When `-C` is absent, behaviour is byte-identical to the current
+  release.
+
+### Implementation
+Edits are confined to `src/pyproject_installer/__main__.py`.
+
+1. Add the option on the top-level parser near the existing
+   `-v` / `--version` block:
+   ```python
+   parser.add_argument(
+       "-C",
+       dest="cwd",
+       type=Path,
+       default=None,
+       metavar="dir",
+       help="change to dir before running subcommand (default: cwd)",
+   )
+   ```
+   The `dest` is `cwd` so reading code (`if args.cwd is not None`) is
+   self-documenting.
+
+2. Defer the two argparse defaults that currently freeze cwd at
+   parser-construction time:
+   - `parser_build.add_argument("srcdir", ..., default=Path.cwd())` →
+     `default=None`; compute `args.srcdir = args.srcdir or Path.cwd()`
+     inside the `build` entry function.
+   - `parser_deps.add_argument("--depsconfig", ...,
+     default=Path.cwd() / DEFAULT_CONFIG_NAME)` → `default=None`;
+     compute the fallback inside the `deps` dispatch before it is used.
+
+   This change has a small independent benefit: the `--help` output
+   no longer embeds the cwd as observed at import time.
+
+3. Perform the `chdir` in `main()` between logging setup and
+   subcommand dispatch:
+   ```python
+   setup_logging(verbose=args.verbose)
+   if args.cwd is not None:
+       try:
+           os.chdir(args.cwd)
+       except OSError as exc:
+           parser.error(f"-C: {exc}")
+       logger.debug("Changed working directory to %s", Path.cwd())
+   args.main(args)
+   ```
+   The single `except OSError` covers `FileNotFoundError`,
+   `NotADirectoryError`, `PermissionError`, and their siblings.
+   `parser.error()` produces the conventional argparse failure output
+   (usage line + exit 2). The debug log is gated by `-v` and serves as
+   an operational breadcrumb; it is not considered part of the stable
+   contract.
+
+No changes are needed in `lib/backend_helper/backend_caller.py` (the
+stdlib-only subprocess inherits cwd from its parent), in the deps
+collectors (all `Path.cwd()` calls there are runtime), or in the
+`build_cmd` / `install_cmd` / `run_cmd` internals.
+
+### Data flow
+1. Python starts with the shell's cwd.
+2. `main_parser()` builds the argparse tree (no cwd-frozen defaults).
+3. `parser.parse_args()` yields a namespace; `args.cwd` is either
+   `None` or a `Path`.
+4. `setup_logging(...)` is configured on stdout / stderr streams only.
+5. If `args.cwd` is set, `os.chdir` is attempted; failures bail via
+   `parser.error`. On success, a debug log is emitted.
+6. `args.main(args)` dispatches. Any runtime `Path.cwd()` call and the
+   deferred argparse fallbacks all resolve against the new cwd.
+7. Subprocesses spawned by the tool inherit the new cwd automatically.
+
+The original cwd is intentionally not preserved: nothing in the tool
+needs it, and storing it would invite downstream callers to reinvent
+`git -C`'s hybrid semantics, which this design rejects.
+
+### Error handling
+Failure modes are handled at the single `except OSError` site:
+- Missing path → `FileNotFoundError`: `-C: [Errno 2] No such file or
+  directory: '<path>'`.
+- Path is a file → `NotADirectoryError`.
+- Path is unreadable → `PermissionError`.
+- Any other `OSError` (symlink loop, ENAMETOOLONG, etc.).
+
+All produce the same argparse-style error output and exit code 2.
+There is no pre-flight `Path.is_dir()` check (TOCTOU) and no custom
+error message rewriting (`OSError.__str__` already includes errno and
+path).
+
+### Testing
+Unit tests are added to `tests/unit/test_main.py`, which already
+houses argparse-level tests for the top-level parser:
+
+1. `-C` absent → cwd unchanged.
+2. `-C <existing-dir>` → cwd equals that directory at subcommand
+   dispatch.
+3. `-C <missing-dir>` → `SystemExit` with exit code 2; stderr contains
+   the errno message.
+4. `-C <relative-path>` → resolved against the original cwd.
+5. Deferred defaults → `args.srcdir` and `args.depsconfig` fall back
+   to `Path.cwd()` post-chdir. Both the user-supplied and the fallback
+   branches are covered.
+
+No new integration tests. The chdir happens in `main()` before any
+subcommand runs, and subprocess cwd inheritance is a stdlib guarantee;
+existing integration tests implicitly exercise the same code path once
+they use `-C`.
+
+### Acceptance criteria
+1. No coverage regression, measured per-file and overall, against the
+   pre-change baseline (`pytest --cov --cov-config=pyproject.toml
+   tests/unit` with `COVERAGE_PROCESS_START` set per project
+   conventions). Both the new `except OSError` branch and both
+   branches of each deferred-default fallback must be covered. If an
+   existing test does not exercise the fallback branch of `srcdir` or
+   `depsconfig`, a targeted test is added to keep that branch covered.
+2. All existing tests pass without modification.
+3. `ruff check .`, `pylint --rcfile=pyproject.toml .`,
+   `black --check --diff .`, and `validate_pyproject -vv pyproject.toml`
+   all pass.
+4. The self-run dogfood flow
+   (`python3 -m pyproject_installer -v build &&
+     python3 -m pyproject_installer -v run -- pytest -vra tests/unit`)
+   completes successfully.
+5. `README.md` is updated with an entry for `-C` containing `name`,
+   `description`, and `example`, per the project's CLI documentation
+   rule.
+
+## Example
+```
+# Build a project without cd'ing into its tree.
+python -m pyproject_installer -C /path/to/project build
+
+# Combined with a subcommand positional: dist/foo.whl is resolved
+# relative to /path/to/project.
+python -m pyproject_installer -C /path/to/project install dist/foo.whl
+
+# Run the project's test suite from anywhere.
+python -m pyproject_installer -C /path/to/project run -- pytest -vra
+```

--- a/src/pyproject_installer/__main__.py
+++ b/src/pyproject_installer/__main__.py
@@ -15,6 +15,7 @@ Install features:
 import argparse
 import json
 import logging
+import os
 import sys
 from pathlib import Path
 
@@ -30,7 +31,8 @@ logger = logging.getLogger(Path(__file__).parent.name)
 
 
 def build(args, parser):
-    outdir = args.srcdir / "dist" if args.outdir is None else args.outdir
+    srcdir = args.srcdir or Path.cwd()
+    outdir = srcdir / "dist" if args.outdir is None else args.outdir
     try:
         config_settings = convert_config_settings(args.backend_config_settings)
     except (ValueError, TypeError) as e:
@@ -38,7 +40,7 @@ def build(args, parser):
 
     build_func = build_sdist if args.sdist else build_wheel
     build_func(
-        args.srcdir,
+        srcdir,
         outdir=outdir,
         config=config_settings,
         verbose=args.verbose,
@@ -61,6 +63,8 @@ def install(args, parser):
 
 def deps(action_name):
     def wrapped(args, parser):
+        depsconfig = args.depsconfig or Path.cwd() / DEFAULT_CONFIG_NAME
+
         if (
             hasattr(args, "depformatextra")
             and args.depformatextra is not None
@@ -73,7 +77,7 @@ def deps(action_name):
 
         kwargs = {x: getattr(args, x) for x in args.main_args}
         try:
-            deps_command(action_name, args.depsconfig, **kwargs)
+            deps_command(action_name, depsconfig, **kwargs)
         except DepsUnsyncedError:
             # sync --verify error
             sys.exit(ExitCodes.SYNC_VERIFY_ERROR)
@@ -425,6 +429,16 @@ def main_parser(prog):
         action="version",
         version=project_version,
     )
+    parser.add_argument(
+        "-C",
+        dest="cwd",
+        default=None,
+        metavar="DIR",
+        help=(
+            "change to DIR before running subcommand "
+            "(default: current working directory)%(default).0s"
+        ),
+    )
 
     subparsers = parser.add_subparsers(
         title="subcommands",
@@ -445,8 +459,11 @@ def main_parser(prog):
         "srcdir",
         type=Path,
         nargs="?",
-        default=Path.cwd(),
-        help="source directory (default: current working directory)",
+        default=None,
+        help=(
+            "source directory "
+            "(default: current working directory)%(default).0s"
+        ),
     )
     parser_build.add_argument(
         "--outdir",
@@ -563,10 +580,10 @@ def main_parser(prog):
     parser_deps.add_argument(
         "--depsconfig",
         type=Path,
-        default=Path.cwd() / DEFAULT_CONFIG_NAME,
+        default=None,
         help=(
             "configuration file to use "
-            f"(default: {{cwd}}/{DEFAULT_CONFIG_NAME})"
+            f"(default: {{cwd}}/{DEFAULT_CONFIG_NAME})%(default).0s"
         ),
     )
 
@@ -606,6 +623,13 @@ def main(cli_args, prog=f"python -m {__package__}"):
     parser = main_parser(prog)
     args = parser.parse_args(cli_args)
     setup_logging(verbose=args.verbose)
+
+    if args.cwd:
+        try:
+            os.chdir(args.cwd)
+        except OSError as e:
+            parser.error(f"-C: {e}")
+        logger.debug("changed working directory to %s", args.cwd)
 
     args.main(args, parser)
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -47,6 +47,30 @@ def mock_read_tracker(mocker):
     )
 
 
+@pytest.fixture
+def preserve_cwd(monkeypatch):
+    """Snapshot and restore the process cwd around a test."""
+    monkeypatch.chdir(Path.cwd())
+
+
+@pytest.fixture
+def record_cwd():
+    """Patch a mocked command to record its cwd"""
+    command_cwd = []
+
+    def _patch_mocked_cmd(mocked_cmd):
+        def _record_cwd():
+            command_cwd[:] = [Path.cwd()]
+
+        def _cwd():
+            return command_cwd[0] if command_cwd else None
+
+        mocked_cmd.side_effect = lambda *_a, **_k: _record_cwd()
+        return _cwd
+
+    return _patch_mocked_cmd
+
+
 def test_version():
     result = subprocess.run(
         args=[sys.executable, "-m", "pyproject_installer", "--version"],
@@ -735,6 +759,329 @@ def test_deps_cli_sync_selected(mock_deps_command, srcnames):
 
     project_main.main(deps_args)
     mock_deps_command.assert_called_once_with(*r_args, **r_kwargs)
+
+
+@pytest.mark.usefixtures("preserve_cwd")
+def test_cwd_chdir_on_valid_dir(mock_build_wheel, record_cwd, tmp_path):
+    """
+    Pass -C with absolute path to valid directory and check if cwd is changed.
+    """
+    cwd = tmp_path.resolve()
+    actual_cwd = record_cwd(mock_build_wheel)
+    project_main.main(["-C", str(cwd), "build"])
+    assert actual_cwd() == cwd
+    mock_build_wheel.assert_called_once()
+
+
+@pytest.mark.usefixtures("preserve_cwd")
+def test_cwd_relative_path_resolves_against_original_cwd(
+    mock_build_wheel,
+    tmp_path,
+    monkeypatch,
+    record_cwd,
+):
+    """
+    Pass -C with relative path to valid directory and check if cwd is changed.
+    """
+    rel_dirname = "pkg"
+    cwd = tmp_path / rel_dirname
+    cwd.mkdir()
+    monkeypatch.chdir(tmp_path)
+    actual_cwd = record_cwd(mock_build_wheel)
+    project_main.main(["-C", rel_dirname, "build"])
+    assert actual_cwd() == cwd
+    mock_build_wheel.assert_called_once()
+
+
+@pytest.mark.usefixtures("preserve_cwd")
+def test_cwd_missing_dir_errors(mock_build_wheel, tmp_path, capsys):
+    """Pass -C with nonexistent directory and check the error"""
+    cwd = tmp_path / "does_not_exist"
+    with pytest.raises(SystemExit) as exc:
+        project_main.main(["-C", str(cwd), "build"])
+    assert exc.value.code == ExitCodes.WRONG_USAGE
+    captured = capsys.readouterr()
+
+    # actual error message is controlled by cpython
+    expected_err_msg = "-C: "
+    assert expected_err_msg in captured.err
+    mock_build_wheel.assert_not_called()
+
+
+@pytest.mark.usefixtures("preserve_cwd")
+def test_cwd_non_dir_errors(mock_build_wheel, tmp_path, capsys):
+    """Pass -C with file (not directory) and check the error"""
+    (cwd := tmp_path / "some_file").touch()
+    with pytest.raises(SystemExit) as exc:
+        project_main.main(["-C", str(cwd), "build"])
+    assert exc.value.code == ExitCodes.WRONG_USAGE
+    captured = capsys.readouterr()
+
+    # actual error message is controlled by cpython
+    expected_err_msg = "-C: "
+    assert expected_err_msg in captured.err
+    mock_build_wheel.assert_not_called()
+
+
+@pytest.mark.usefixtures("preserve_cwd")
+def test_cwd_empty_string_no_change(mock_build_wheel, record_cwd):
+    """Pass -C "" and check if cwd is left unchanged"""
+    cwd = ""
+    actual_cwd = record_cwd(mock_build_wheel)
+    project_main.main(["-C", str(cwd), "build"])
+    assert actual_cwd() == Path.cwd()
+    mock_build_wheel.assert_called_once()
+
+
+@pytest.mark.usefixtures("preserve_cwd")
+def test_cwd_unchanged_without_flag(mock_build_wheel, record_cwd):
+    """Don't pass -C and check if cwd is left unchanged"""
+    actual_cwd = record_cwd(mock_build_wheel)
+    project_main.main(["build"])
+    assert actual_cwd() == Path.cwd()
+    mock_build_wheel.assert_called_once()
+
+
+@pytest.mark.usefixtures("preserve_cwd")
+def test_cwd_default_srcdir_build(mock_build_wheel, tmp_path, record_cwd):
+    """
+    Pass -C with valid absolute directory and check if default srcdir changed
+    for build command.
+    """
+    cwd = tmp_path.resolve()
+    actual_cwd = record_cwd(mock_build_wheel)
+    project_main.main(["-C", str(cwd), "build"])
+    assert actual_cwd() == cwd
+    call_args, call_kwargs = mock_build_wheel.call_args
+    assert call_args[0] == cwd
+    assert call_kwargs["outdir"] == cwd / "dist"
+
+
+@pytest.mark.usefixtures("preserve_cwd")
+def test_cwd_rel_srcdir_build(mock_build_wheel, tmp_path, record_cwd):
+    """
+    Pass -C with valid absolute directory and check if relative srcdir is not
+    changed for build command.
+    """
+    cwd = tmp_path.resolve()
+    srcdir = Path("srcdir")
+    actual_cwd = record_cwd(mock_build_wheel)
+    project_main.main(["-C", str(cwd), "build", str(srcdir)])
+    assert actual_cwd() == cwd
+    call_args, call_kwargs = mock_build_wheel.call_args
+    assert call_args[0] == srcdir
+    assert call_kwargs["outdir"] == srcdir / "dist"
+
+
+@pytest.mark.usefixtures("preserve_cwd")
+def test_cwd_abs_srcdir_build(mock_build_wheel, tmp_path, record_cwd):
+    """
+    Pass -C with valid absolute directory and check if absolute srcdir is not
+    changed for build command.
+    """
+    cwd = tmp_path.resolve()
+    srcdir = Path("/srcdir")
+    actual_cwd = record_cwd(mock_build_wheel)
+    project_main.main(["-C", str(cwd), "build", str(srcdir)])
+    assert actual_cwd() == cwd
+    call_args, call_kwargs = mock_build_wheel.call_args
+    assert call_args[0] == srcdir
+    assert call_kwargs["outdir"] == srcdir / "dist"
+
+
+@pytest.mark.usefixtures("preserve_cwd")
+def test_cwd_default_depsconfig_deps(mock_deps_command, tmp_path, record_cwd):
+    """
+    Pass -C with valid absolute directory and check if default depsconfig
+    changed for deps command.
+    """
+    cwd = tmp_path.resolve()
+    actual_cwd = record_cwd(mock_deps_command)
+    project_main.main(["-C", str(cwd), "deps", "show"])
+    assert actual_cwd() == cwd
+    call_args, _ = mock_deps_command.call_args
+    assert call_args[1] == cwd / project_main.DEFAULT_CONFIG_NAME
+
+
+@pytest.mark.usefixtures("preserve_cwd")
+def test_cwd_rel_depsconfig_deps(mock_deps_command, tmp_path, record_cwd):
+    """
+    Pass -C with valid absolute directory and check if relative depsconfig
+    is not changed for deps command.
+    """
+    cwd = tmp_path.resolve()
+    depsconfig = Path("depsconfig")
+    actual_cwd = record_cwd(mock_deps_command)
+    project_main.main(
+        ["-C", str(cwd), "deps", "--depsconfig", str(depsconfig), "show"],
+    )
+    assert actual_cwd() == cwd
+    call_args, _ = mock_deps_command.call_args
+    assert call_args[1] == depsconfig
+
+
+@pytest.mark.usefixtures("preserve_cwd")
+def test_cwd_abs_depsconfig_deps(mock_deps_command, tmp_path, record_cwd):
+    """
+    Pass -C with valid absolute directory and check if absolute depsconfig
+    is not changed for deps command.
+    """
+    cwd = tmp_path.resolve()
+    depsconfig = Path("/depsconfig")
+    actual_cwd = record_cwd(mock_deps_command)
+    project_main.main(
+        ["-C", str(cwd), "deps", "--depsconfig", str(depsconfig), "show"],
+    )
+    assert actual_cwd() == cwd
+    call_args, _ = mock_deps_command.call_args
+    assert call_args[1] == depsconfig
+
+
+@pytest.mark.usefixtures("preserve_cwd")
+def test_cwd_default_wheel_install(
+    mock_install_wheel,
+    mock_read_tracker,
+    tmp_path,
+    record_cwd,
+):
+    """
+    Pass -C with valid absolute directory and check default wheel for install
+    command.
+    """
+    cwd = tmp_path.resolve()
+    expected_wheel = cwd / "dist" / "foo.whl"
+    expected_tracker = cwd / "dist" / project_main.WHEEL_TRACKER
+    actual_cwd = record_cwd(mock_install_wheel)
+    project_main.main(["-C", str(cwd), "install"])
+    assert actual_cwd() == cwd
+    mock_read_tracker.assert_called_once_with(
+        expected_tracker,
+        encoding="utf-8",
+    )
+    call_args, _ = mock_install_wheel.call_args
+    assert call_args[0] == expected_wheel
+
+
+@pytest.mark.usefixtures("preserve_cwd")
+def test_cwd_rel_wheel_install(
+    mock_install_wheel,
+    mock_read_tracker,
+    tmp_path,
+    record_cwd,
+):
+    """
+    Pass -C with valid absolute directory and check relative wheel for install
+    command.
+    """
+    cwd = tmp_path.resolve()
+    wheel = Path("wheel")
+    actual_cwd = record_cwd(mock_install_wheel)
+    project_main.main(["-C", str(cwd), "install", str(wheel)])
+    assert actual_cwd() == cwd
+    mock_read_tracker.assert_not_called()
+    call_args, _ = mock_install_wheel.call_args
+    assert call_args[0] == wheel
+
+
+@pytest.mark.usefixtures("preserve_cwd")
+def test_cwd_abs_wheel_install(
+    mock_install_wheel,
+    mock_read_tracker,
+    tmp_path,
+    record_cwd,
+):
+    """
+    Pass -C with valid absolute directory and check absolute wheel for install
+    command.
+    """
+    cwd = tmp_path.resolve()
+    wheel = Path("/wheel")
+    actual_cwd = record_cwd(mock_install_wheel)
+    project_main.main(["-C", str(cwd), "install", str(wheel)])
+    assert actual_cwd() == cwd
+    mock_read_tracker.assert_not_called()
+    call_args, _ = mock_install_wheel.call_args
+    assert call_args[0] == wheel
+
+
+@pytest.mark.usefixtures("preserve_cwd")
+def test_cwd_default_wheel_run(
+    mock_run_command,
+    mock_read_tracker,
+    tmp_path,
+    record_cwd,
+):
+    """
+    Pass -C with valid absolute directory and check default wheel for run
+    command.
+    """
+
+    cwd = tmp_path.resolve()
+    expected_wheel = cwd / "dist" / "foo.whl"
+    expected_tracker = cwd / "dist" / project_main.WHEEL_TRACKER
+    actual_cwd = record_cwd(mock_run_command)
+    with pytest.raises(SystemExit) as exc:
+        project_main.main(["-C", str(cwd), "run", "--", "true"])
+    assert exc.value.code == ExitCodes.OK
+    assert actual_cwd() == cwd
+    mock_read_tracker.assert_called_once_with(
+        expected_tracker,
+        encoding="utf-8",
+    )
+    call_args, _ = mock_run_command.call_args
+    assert call_args[0] == expected_wheel
+
+
+@pytest.mark.usefixtures("preserve_cwd")
+def test_cwd_rel_wheel_run(
+    mock_run_command,
+    mock_read_tracker,
+    tmp_path,
+    record_cwd,
+):
+    """
+    Pass -C with valid absolute directory and check relative wheel for run
+    command.
+    """
+
+    cwd = tmp_path.resolve()
+    wheel = Path("wheel")
+    actual_cwd = record_cwd(mock_run_command)
+    with pytest.raises(SystemExit) as exc:
+        project_main.main(
+            ["-C", str(cwd), "run", "--wheel", str(wheel), "--", "true"],
+        )
+    assert exc.value.code == ExitCodes.OK
+    assert actual_cwd() == cwd
+    mock_read_tracker.assert_not_called()
+    call_args, _ = mock_run_command.call_args
+    assert call_args[0] == wheel
+
+
+@pytest.mark.usefixtures("preserve_cwd")
+def test_cwd_abs_wheel_run(
+    mock_run_command,
+    mock_read_tracker,
+    tmp_path,
+    record_cwd,
+):
+    """
+    Pass -C with valid absolute directory and check absolute wheel for run
+    command.
+    """
+
+    cwd = tmp_path.resolve()
+    wheel = Path("/wheel")
+    actual_cwd = record_cwd(mock_run_command)
+    with pytest.raises(SystemExit) as exc:
+        project_main.main(
+            ["-C", str(cwd), "run", "--wheel", str(wheel), "--", "true"],
+        )
+    assert exc.value.code == ExitCodes.OK
+    assert actual_cwd() == cwd
+    mock_read_tracker.assert_not_called()
+    call_args, _ = mock_run_command.call_args
+    assert call_args[0] == wheel
 
 
 def test_deps_cli_sync_verify(mock_deps_command):


### PR DESCRIPTION
Every existing subcommand derives at least one default path from `Path.cwd()`:
- `build` takes `srcdir` from cwd.
- `install` / `run` look up the wheel via `{cwd}/dist/<WHEEL_TRACKER>`.
- `deps` reads `{cwd}/<DEFAULT_CONFIG_NAME>` and each collector calls `Path.cwd()` at runtime.

Today, operating on a project that isn't the shell's current directory requires wrapping every invocation with `cd <dir> && python -m pyproject_installer ...` (and restoring cwd afterwards). RPM specs and other packaging macros frequently know the source tree absolute path up front; passing it as a flag is more ergonomic than composing a shell sequence, and it removes the need for callers to manage cwd state.

See for details:
docs/designs/change_dir_option.md

Fixes: https://github.com/stanislavlevin/pyproject_installer/issues/133

## Summary by Sourcery

Add a global -C option to change the working directory before running CLI subcommands and align default path resolution with the updated cwd.

New Features:
- Introduce a top-level -C DIR CLI option that changes the process working directory before dispatching subcommands, affecting all path-based defaults.

Enhancements:
- Defer srcdir and depsconfig default resolution to runtime so they derive from the (possibly updated) current working directory instead of parser construction time.

Documentation:
- Document the new -C option and its semantics in the README and add a detailed design document explaining the change-dir behavior and rationale.

Tests:
- Add unit tests covering -C cwd changes, error handling for invalid directories, relative path resolution, and post-chdir default path behavior across subcommands.