### PR TITLE
feat: add --rpm-filelist install option

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,65 @@ python -m pyproject_installer install
 >
 > *Example:* `python -m pyproject_installer install --no-strip-dist-info`
 
+> **`--rpm-filelist PATH`**
+>
+> Write an RPM `%files`-compatible filelist of every installed file, plus the computed `.pyc` paths for every installed `.py` under `purelib`/`platlib` (PEP 3147 / PEP 488). The file is consumable by `%files -f <PATH>` without post-processing, letting a spec declare package contents as `%files -f dist/foo.files` rather than enumerating them by hand. Paths in the output are system-absolute (`--destdir` is stripped). Parent directory of `PATH` must exist.
+>
+> *What is emitted:*
+>
+> - *File lines* - every file the installer writes to `--destdir`: `.py` sources, compiled extensions, entry-point scripts, dist-info files (`METADATA`, and with `--no-strip-dist-info` every file that survives filtering), the `INSTALLER` file (when `--installer` is used), and the relocated contents of `{dist}-{ver}.data/<scheme>/`.
+> - *`.pyc` expansion* - for every `.py` file whose deepest owning scheme is `purelib` or `platlib`, three bytecode paths are computed (`importlib.util.cache_from_source` at optimisation levels 0, 1, 2) and emitted. `.py` files outside `purelib`/`platlib` (scripts, data, headers, dist-info) are **not** expanded: RPM's bytecompile step does not compile them, so predicting `.pyc` there would yield phantom paths that fail `%files` parsing.
+> - *Man page globbing* - files under `scheme["data"]/share/man/` get a trailing `*` so the filelist still matches after RPM's `brp-compress` compresses them post-`%install` (uncompressed pages gain a compression extension). Suffixes brp decompresses (`.gz`, `.bz2`, `.Z`) are stripped first - brp will recompress them, so the on-disk extension may differ from the wheel's. Others (`.xz`, `.zst`, ...) are kept literal - brp leaves them alone.
+> - *`%dir` entries* - directories the package claims ownership of:
+>   - `{dist}-{ver}.dist-info` is **always** owned (installer creates it even when stripped down to `METADATA`); its subdirectories (e.g. PEP 639 `licenses/` under `--no-strip-dist-info`) are owned too.
+>   - `scheme["headers"]` (typically `/usr/include/pythonX.Y/<dist>`, per-distribution namespaced) is owned only when at least one installed file lives under it; its intermediate subdirectories are owned too.
+>   - Every intermediate directory between an installed file and its owning scheme root - i.e. package and sub-package dirs under `purelib`/`platlib` - is owned. For `.py` files in sub-packages, the sibling `__pycache__` directory is owned.
+>
+> *What is deliberately **not** emitted:*
+>
+> - The site roots themselves (`scheme["purelib"]`, `scheme["platlib"]` - e.g. `/usr/lib/pythonX.Y/site-packages`, `/usr/lib64/pythonX.Y/site-packages`) - owned by the Python runtime package.
+> - The shared site-level `__pycache__` (`/usr/lib{,64}/pythonX.Y/site-packages/__pycache__`) - every top-level single-file module would fight for ownership; no `%dir` is emitted even though `.pyc` file lines for top-level modules land inside it.
+> - `%dir` for FHS-standard roots (`/usr/bin`, `/usr/share`, etc.) or any intermediate directory under them. Files installed to `scheme["scripts"]` or `scheme["data"]` are emitted *file-only*; if your package ships app-specific data directories that no other package owns, add `%dir` lines for them manually in the spec.
+>
+> *Note:* `sys.pycache_prefix` must be at its default (`None`). `importlib.util.cache_from_source` respects it, so any non-default value (`PYTHONPYCACHEPREFIX`, `-X pycache_prefix=...`) would redirect every computed `.pyc` path under that prefix and desync the filelist from the buildroot; the installer refuses to run with `--rpm-filelist` in that case.
+>
+> *Default:* `None`, filelist is not written
+>
+> *Example:* `python -m pyproject_installer install --destdir /tmp/buildroot --rpm-filelist dist/foo.files`
+>
+> *Example output* - `dist/foo.files` after installing a pure-Python `foo-1.0-py3-none-any.whl` containing the `foo` package, a `foo_cli` console script, and a `.data/data/share/foo/asset.dat` asset on Python 3.13 with purelib = `/usr/lib/python3/site-packages`:
+>
+> ```
+> %dir /usr/lib/python3/site-packages/foo
+> %dir /usr/lib/python3/site-packages/foo-1.0.dist-info
+> %dir /usr/lib/python3/site-packages/foo/__pycache__
+> /usr/bin/foo_cli
+> /usr/lib/python3/site-packages/foo-1.0.dist-info/METADATA
+> /usr/lib/python3/site-packages/foo-1.0.dist-info/entry_points.txt
+> /usr/lib/python3/site-packages/foo/__init__.py
+> /usr/lib/python3/site-packages/foo/__pycache__/__init__.cpython-313.opt-1.pyc
+> /usr/lib/python3/site-packages/foo/__pycache__/__init__.cpython-313.opt-2.pyc
+> /usr/lib/python3/site-packages/foo/__pycache__/__init__.cpython-313.pyc
+> /usr/share/foo/asset.dat
+> ```
+>
+> Emitted paths follow `sysconfig.get_paths()` of the running interpreter. For a platform-specific wheel (e.g. `foo-1.0-cp313-cp313-linux_x86_64.whl`) on a split `lib`/`lib64` layout where platlib = `/usr/lib64/python3/site-packages`, the same contents plus a compiled extension land under the platlib root:
+>
+> ```
+> %dir /usr/lib64/python3/site-packages/foo
+> %dir /usr/lib64/python3/site-packages/foo-1.0.dist-info
+> %dir /usr/lib64/python3/site-packages/foo/__pycache__
+> /usr/bin/foo_cli
+> /usr/lib64/python3/site-packages/foo-1.0.dist-info/METADATA
+> /usr/lib64/python3/site-packages/foo-1.0.dist-info/entry_points.txt
+> /usr/lib64/python3/site-packages/foo/__init__.py
+> /usr/lib64/python3/site-packages/foo/__pycache__/__init__.cpython-313.opt-1.pyc
+> /usr/lib64/python3/site-packages/foo/__pycache__/__init__.cpython-313.opt-2.pyc
+> /usr/lib64/python3/site-packages/foo/__pycache__/__init__.cpython-313.pyc
+> /usr/lib64/python3/site-packages/foo/_ext.cpython-313-x86_64-linux-gnu.so
+> /usr/share/foo/asset.dat
+> ```
+
 ### Run
 
 Run command within Python virtual environment that has access to system and user

--- a/docs/designs/rpm_filelist_option.md
+++ b/docs/designs/rpm_filelist_option.md
@@ -1,0 +1,86 @@
+## Abstract
+This RFE proposes a new opt-in install option `--rpm-filelist PATH`
+that emits a deterministic RPM `%files`-compatible filelist describing
+every file written by the installer, plus the computed bytecompiled
+`.pyc` paths for every installed `.py` under purelib/platlib
+(PEP 3147 / PEP 488). The file is consumable by rpm's `%files -f`
+directive without post-processing.
+
+## Motivation
+The project's primary downstream consumer is RPM packaging: a spec
+file runs `pyproject_installer build && pyproject_installer install
+--destdir %{buildroot}`, then declares the package contents in
+`%files`. Today the packager enumerates those files by hand (or with
+globs), which:
+
+- duplicates knowledge the installer already has (scheme paths,
+  `.data/` relocation, dist-info filtering, generated entry-point
+  scripts);
+- is fragile across distros with different purelib/platlib layouts;
+- misses or double-claims `__pycache__/*.pyc` files that RPM's
+  bytecompile step produces post-install - the glob surface there is
+  tag-dependent (`cpython-312`, `cpython-313`, ...) and varies per
+  build.
+
+The installer already knows, at install time, exactly which files
+land where and which `.py` files will later be bytecompiled by RPM.
+Emitting that knowledge as a filelist removes duplication in every
+spec and matches the RPM workflow `%files -f <filelist>`.
+
+The filelist is opt-in because:
+
+- the default behaviour (byte-identical to today) is unchanged -
+  callers who don't set the flag pay nothing;
+- not every consumer of the installer builds RPMs (some use the same
+  destdir mechanic for containers, chroots, etc.);
+- writing a side file under `destdir` would pollute the buildroot
+  with content that RPM later flags as unpackaged - the filelist
+  must live outside the buildroot.
+
+## Specification
+
+### User-facing contract
+- Syntax: `python -m pyproject_installer install --rpm-filelist <PATH>
+  [other install args...]`.
+- `--rpm-filelist` is declared on the `install` subparser only.
+- `<PATH>` is a filesystem path. Relative paths resolve against the
+  current working directory (after any `-C <dir>` handling in
+  `main()`). Parent directory must exist; if it doesn't, the write
+  step fails with `FileNotFoundError`. No `mkdir`: layout is the
+  caller's responsibility.
+- An existing target is overwritten.
+- Output format: UTF-8, LF line endings, trailing newline, sorted
+  ascending. Each non-empty line is either `<path>` (file) or
+  `%dir <path>` (directory entry), with a single space separator
+  after `%dir`.
+- Paths are **system-absolute, destdir stripped**. Given
+  `--destdir /tmp/buildroot` and a wheel targeting purelib at
+  `/usr/lib/python3/site-packages`, emitted lines look like
+  `/usr/lib/python3/site-packages/foo/__init__.py` (not
+  `/tmp/buildroot/usr/...`). The purelib/platlib roots are taken
+  from `sysconfig.get_paths()` of the running interpreter; on a
+  split `lib`/`lib64` layout the two differ
+  (e.g. platlib = `/usr/lib64/python3/site-packages`).
+- When `--rpm-filelist` is absent, behaviour is byte-identical to
+  the current release.
+- Programmatic API: `install_wheel(..., rpm_filelist=None)` accepts
+  `Path | None`.
+- Precondition: `sys.pycache_prefix` must be at its default
+  (`None`). `importlib.util.cache_from_source` respects it, so a
+  non-default value (via `PYTHONPYCACHEPREFIX` or
+  `-X pycache_prefix=...`) would redirect every computed `.pyc`
+  path under that prefix and desync the filelist from the
+  buildroot. Enforced inside `render_rpm_filelist` before any path
+  composition runs: violations raise `ValueError`.
+
+## Example
+
+```
+# Install into a buildroot and emit the filelist alongside the wheel.
+python -m pyproject_installer install \
+    --destdir /tmp/buildroot \
+    --rpm-filelist dist/foo.files
+
+# In the .spec file:
+%files -f dist/foo.files
+```

--- a/src/pyproject_installer/__main__.py
+++ b/src/pyproject_installer/__main__.py
@@ -58,6 +58,7 @@ def install(args, parser):
         destdir=args.destdir,
         installer=args.installer,
         strip_dist_info=args.strip_dist_info,
+        rpm_filelist=args.rpm_filelist,
     )
 
 
@@ -536,6 +537,17 @@ def main_parser(prog):
             "entry_points.txt files are allowed in dist-info directory. "
             "Note: RECORD is unconditionally filtered out. "
             "(default: False)"
+        ),
+    )
+    parser_install.add_argument(
+        "--rpm-filelist",
+        type=Path,
+        default=None,
+        metavar="PATH",
+        help=(
+            "write an RPM %%files-compatible filelist of installed "
+            "files (plus computed .pyc paths) to PATH "
+            "(default: None, filelist is not written)"
         ),
     )
     parser_install.set_defaults(main=install)

--- a/src/pyproject_installer/install_cmd/_install.py
+++ b/src/pyproject_installer/install_cmd/_install.py
@@ -5,6 +5,9 @@ import sysconfig
 from importlib.metadata import PathDistribution
 from pathlib import Path
 
+from pyproject_installer.install_cmd._rpm_filelist import (
+    write_rpm_filelist,
+)
 from pyproject_installer.lib.scripts import (
     build_shebang,
     generate_entrypoints_scripts,
@@ -44,20 +47,40 @@ def get_installation_scheme(dist_name):
     return scheme_dict
 
 
-def install_wheel_data(data_path, scheme, destdir):
+def install_wheel_data(data_path, scheme, destdir, *, installed_paths=None):
     """
     PEP427:
     Each subdirectory of distribution-1.0.data/ is a key into a dict of
     destination directories, such as
     distribution-1.0.data/(purelib|platlib|headers|scripts|data). The initially
     supported paths are taken from distutils.command.install.
+
+    If `installed_paths` is not None, each destination file's path is
+    added to it as `shutil.copytree` creates it. The hook is installed
+    via the `copy_function` parameter, so every regular file copytree
+    emits (including symlink-target copies under the default
+    `symlinks=False`) is observed exactly once.
     """
     logger.info("Installing .data")
+
+    if installed_paths is None:
+        copy_fn = shutil.copy2
+    else:
+
+        def copy_fn(src, dst):
+            shutil.copy2(src, dst)
+            installed_paths.add(Path(dst))
+
     # keys of .data dir were prechecked in `validate`
     for f in data_path.iterdir():
         path = Path(scheme[f.name]).absolute()
         rootdir = destdir / path.relative_to(path.root)
-        shutil.copytree(data_path / f, rootdir, dirs_exist_ok=True)
+        shutil.copytree(
+            data_path / f,
+            rootdir,
+            dirs_exist_ok=True,
+            copy_function=copy_fn,
+        )
 
         if f.name == "scripts":
             # PEP427
@@ -138,6 +161,7 @@ def install_wheel(
     destdir,
     installer=None,
     strip_dist_info=True,
+    rpm_filelist=None,
 ):
     wheel_path = validate_wheel_path(wheel_path)
     destdir = validate_destdir(destdir)
@@ -150,20 +174,34 @@ def install_wheel(
     with WheelFile(wheel_path) as whl:
         dist_name = whl.dist_name
         dist_version = whl.dist_version
+        data_name = whl.data_name
         scheme = get_installation_scheme(dist_name)
         extraction_root = whl.extraction_root(scheme)
         rootdir = destdir / extraction_root.relative_to(extraction_root.root)
         logger.info("Wheel installation root: %s", rootdir)
 
         dist_info = f"{dist_name}-{dist_version}.dist-info"
-        members = filter_dist_info(
-            dist_info,
-            members=whl.memberlist,
-            strip_dist_info=strip_dist_info,
+        members = tuple(
+            filter_dist_info(
+                dist_info,
+                members=whl.memberlist,
+                strip_dist_info=strip_dist_info,
+            ),
         )
+
+        installed_paths = set() if rpm_filelist is not None else None
 
         logger.info("Extracting wheel")
         whl.extract(rootdir, members=members)
+        if installed_paths is not None:
+            # Skip .data/* members: install_wheel_data relocates them
+            # to their scheme destinations below and records the final
+            # paths. Recording the pre-move paths would emit phantom
+            # entries (the .data/ tree is rmtree'd after relocation).
+            for m in members:
+                if Path(m).parts[0] == data_name:
+                    continue
+                installed_paths.add(rootdir / m)
 
     dist_info_path = rootdir / dist_info
 
@@ -174,15 +212,32 @@ def install_wheel(
             python=sys.executable,
             scriptsdir=Path(scheme["scripts"]).absolute(),
             destdir=destdir,
+            installed_paths=installed_paths,
         )
 
     if installer is not None:
         # write installer of this distribution if requested
         installer_path = dist_info_path / "INSTALLER"
         installer_path.write_text(f"{installer}\n", encoding="utf-8")
+        if installed_paths is not None:
+            installed_paths.add(installer_path)
 
-    data_path = rootdir / f"{dist_name}-{dist_version}.data"
+    data_path = rootdir / data_name
     if data_path.exists():
-        install_wheel_data(data_path, scheme=scheme, destdir=destdir)
+        install_wheel_data(
+            data_path,
+            scheme=scheme,
+            destdir=destdir,
+            installed_paths=installed_paths,
+        )
+
+    if installed_paths is not None:
+        write_rpm_filelist(
+            rpm_filelist,
+            installed_paths,
+            destdir=destdir,
+            scheme=scheme,
+            dist_info=str(extraction_root / dist_info),
+        )
 
     logger.info("Wheel was installed")

--- a/src/pyproject_installer/install_cmd/_rpm_filelist.py
+++ b/src/pyproject_installer/install_cmd/_rpm_filelist.py
@@ -1,0 +1,215 @@
+"""
+RPM %files-compatible filelist generation for `install_wheel`.
+
+Requires `sys.pycache_prefix` to be at its default (`None`):
+`cache_from_source` respects it, so any non-default value would
+silently shift every .pyc path in the filelist under that prefix.
+Enforced at render time.
+
+Internal helper; the public contract is
+`install_wheel(..., rpm_filelist=...)` in `_install.py`. Callers
+collect installed file paths into a set and hand it, along with the
+destdir and the scheme (as returned by `get_installation_scheme()`),
+to `write_rpm_filelist`.
+"""
+
+import sys
+from importlib.util import cache_from_source
+from itertools import chain
+from pathlib import Path
+
+# Standard CPython optimization levels per PEP 488; argument to
+# importlib.util.cache_from_source. Not exposed as a stdlib constant,
+# so duplicated here with a single source of truth.
+PYC_OPTIMIZATION_LEVELS = ("", "1", "2")
+
+# Compression extensions brp-compress decompresses on a man page.
+# If the wheel ships the page with one of these, brp will then
+# recompress with the distro's configured method, and the on-disk
+# extension may not match the wheel's. Stripping these suffixes
+# before appending the `*` glob lets the filelist line cover whichever
+# target the BRP picks. Other extensions (.xz, .zst, .lz, ...) are
+# left alone by brp-compress and so are kept as-is.
+MAN_COMPRESSION_SUFFIXES = frozenset({".gz", ".bz2", ".Z"})
+
+
+def render_rpm_filelist(files, *, destdir, scheme, dist_info):
+    """
+    Return an RPM %files-compatible filelist body for ``files``.
+
+    Inputs
+    ------
+    ``files``
+        Iterable of absolute filesystem paths, each under ``destdir``.
+    ``destdir``
+        Buildroot root; stripped from every path so the filelist holds
+        target-system (post-install) paths.
+    ``scheme``
+        Mapping from ``get_installation_scheme()``. ``purelib``,
+        ``platlib``, ``headers``, and ``data`` are consumed; other
+        keys ignored.
+    ``dist_info``
+        Target-system absolute path of the ``.dist-info`` directory.
+
+    Four **anchors** are derived: ``dist_info``, ``headers``,
+    ``purelib``, ``platlib``. Each input file is classified by its
+    deepest matching anchor (by ``len(Path.parts)``), or left
+    unclassified if it lives outside all four.
+
+    Emitted file lines
+    ------------------
+    1. Every input file, with ``destdir`` stripped.
+    2. Three computed ``.pyc`` paths per PEP 3147 / PEP 488
+       optimisation level (``0``, ``1``, ``2``) for every ``.py`` file
+       whose deepest anchor is ``purelib`` or ``platlib``.
+       ``.py`` files elsewhere (scripts, data, headers, dist-info) are
+       not expanded - RPM's bytecompile step does not compile them.
+
+    Emitted ``%dir`` lines
+    ----------------------
+    1. ``dist_info`` unconditionally - the installer creates it even
+       when stripped down to ``METADATA``.
+    2. ``headers`` only when at least one input file lives under it.
+    3. For every classified input file: each strict ancestor of the
+       file that is also a strict descendant of its anchor (i.e. the
+       intermediate directories between the file and its anchor,
+       open on both ends). The anchors themselves are never added via
+       this rule - site roots are owned by the Python runtime package;
+       ``dist_info`` and ``headers`` are handled by rules 1 and 2.
+    4. The sibling ``__pycache__`` for every ``.py`` file classified
+       under ``purelib``/``platlib`` whose parent is *not* the anchor
+       itself (the shared site-level ``__pycache__`` is never owned).
+
+    Files outside every anchor (e.g. ``scheme["scripts"]``,
+    ``scheme["data"]``) are emitted file-only: no ``%dir`` ownership is
+    claimed on their ancestors, so the filelist does not conflict with
+    FHS-standard directories owned by the ``filesystem`` package
+    (``/usr/bin``, ``/usr/share`` etc.).
+
+    Man pages under ``scheme["data"]/share/man/`` are emitted with a
+    trailing ``*`` because RPM's ``brp-compress`` runs after
+    ``%install`` and compresses uncompressed pages with the distro's
+    configured method, which appends a compression extension to the
+    filename. A literal path no longer matches once that happens; the
+    ``*`` lets a single line match the file regardless of which
+    compression extension (if any) ends up on disk.
+
+    Suffixes in ``MAN_COMPRESSION_SUFFIXES`` (``.gz``, ``.bz2``,
+    ``.Z`` -- the formats ``brp-compress`` decompresses before the
+    recompression pass) are stripped before the glob is appended,
+    because the resulting on-disk extension may differ from the
+    wheel's. Other suffixes (``.xz``, ``.zst``, ``.lz``, ...) are
+    kept literal -- ``brp-compress`` doesn't touch them, so
+    ``<name>.<section>.<ext>*`` matches the wheel's untouched output
+    exactly.
+
+    Output
+    ------
+    All emitted lines - files and ``%dir`` - merged into one list and
+    sorted ASCII-ascending. ``%dir`` lines precede plain file lines
+    at the same prefix (``%`` < ``/``). Body ends with a single
+    trailing newline.
+
+    Raises
+    ------
+    ``ValueError`` if ``sys.pycache_prefix`` is non-default:
+    ``cache_from_source`` honours the prefix, so every computed
+    ``.pyc`` path would be silently shifted out of the install tree.
+    """
+    if sys.pycache_prefix is not None:
+        raise ValueError(
+            "rpm-filelist requires sys.pycache_prefix to be at its "
+            "default (None); PYTHONPYCACHEPREFIX / -X pycache_prefix "
+            "would redirect computed .pyc paths and corrupt the "
+            "filelist",
+        )
+
+    destdir = Path(destdir)
+    dist_info = Path(dist_info)
+    purelib, platlib, headers = (
+        Path(scheme[n]) for n in ("purelib", "platlib", "headers")
+    )
+    anchors = (dist_info, headers, purelib, platlib)
+    man_root = Path(scheme["data"]) / "share" / "man"
+
+    out_files = set()
+    # always own .dist-info dir
+    dirs = {dist_info}
+
+    for raw in files:
+        f = Path("/") / Path(raw).relative_to(destdir)
+        out_files.add(f)
+
+        # deepest match
+        anchor = max(
+            (a for a in anchors if a in f.parents),
+            key=lambda a: len(a.parts),
+            default=None,
+        )
+
+        # file is outside every anchor (scripts, data),
+        # its parents are not processed
+        if anchor is None:
+            continue
+
+        # own the headers root (per-dist namespaced) once occupied
+        if anchor == headers:
+            dirs.add(headers)
+
+        # directories between anchor and file's direct parent
+        for p in f.parents:
+            if p == anchor:
+                break
+            dirs.add(p)
+
+        # compiled cache in sitepackages
+        if anchor in (purelib, platlib) and f.suffix == ".py":
+            # own __pycache__ dir unless it's the sitepackages root
+            if f.parent != anchor:
+                dirs.add(f.parent / "__pycache__")
+            # .py files expand to .pyc paths
+            out_files.update(
+                Path(cache_from_source(str(f), optimization=o))
+                for o in PYC_OPTIMIZATION_LEVELS
+            )
+
+    def render_file(p):
+        rp = str(p)
+
+        # brp-compress compresses uncompressed man pages after %install
+        # returns (foo.1 -> foo.1.xz), and decompresses-then-recompresses
+        # pages that arrive with .gz/.bz2/.Z (foo.1.gz -> foo.1.xz).
+        # Emit the name-plus-section stem with a trailing * so the line
+        # matches both compressed and uncompressed forms. If the wheel
+        # shipped an already-compressed page, drop that extension first
+        # so the glob isn't tied to the source format.
+        if man_root in p.parents:
+            if p.suffix in MAN_COMPRESSION_SUFFIXES:
+                rp = f"{p.parent}/{p.stem}*"
+            else:
+                rp = f"{p}*"
+        return rp
+
+    lines = sorted(
+        chain(
+            (render_file(p) for p in out_files),
+            (f"%dir {p}" for p in dirs),
+        ),
+    )
+    return "\n".join(lines) + "\n"
+
+
+def write_rpm_filelist(out_path, files, *, destdir, scheme, dist_info):
+    """
+    Render the filelist for ``files`` and write it to ``out_path``.
+    Permissions follow the process umask.
+    """
+    Path(out_path).write_text(
+        render_rpm_filelist(
+            files,
+            destdir=destdir,
+            scheme=scheme,
+            dist_info=dist_info,
+        ),
+        encoding="utf-8",
+    )

--- a/src/pyproject_installer/lib/scripts.py
+++ b/src/pyproject_installer/lib/scripts.py
@@ -33,10 +33,20 @@ def build_shebang(executable):
     return "#!/bin/sh\n'''exec' " + executable + ' "$0" "$@"\n' + "' '''"
 
 
-def generate_entrypoints_scripts(distr, python, scriptsdir, destdir):
+def generate_entrypoints_scripts(
+    distr,
+    python,
+    scriptsdir,
+    destdir,
+    *,
+    installed_paths=None,
+):
     """
     Optional entry_points
     https://packaging.python.org/en/latest/specifications/entry-points/
+
+    If `installed_paths` is not None, each generated script's
+    destination path is added to it as the script is written.
     """
     for ep_group in ("console_scripts", "gui_scripts"):
         for ep in distr.entry_points.select(group=ep_group):
@@ -52,3 +62,5 @@ def generate_entrypoints_scripts(distr, python, scriptsdir, destdir):
             script_path = rootdir / ep.name
             script_path.write_text(script_text, encoding="utf-8")
             script_path.chmod(script_path.stat().st_mode | 0o555)
+            if installed_paths is not None:
+                installed_paths.add(script_path)

--- a/src/pyproject_installer/lib/wheel.py
+++ b/src/pyproject_installer/lib/wheel.py
@@ -76,7 +76,8 @@ class WheelFile:
         self.dist_info = (
             self.root / f"{self.dist_name}-{self.dist_version}.dist-info"
         )
-        self.data = self.root / f"{self.dist_name}-{self.dist_version}.data"
+        self.data_name = f"{self.dist_name}-{self.dist_version}.data"
+        self.data = self.root / self.data_name
         self._wheel_metadata = None
         self.validate()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,15 +13,28 @@ from pyproject_installer.lib.wheel import digest_for_record
 
 
 class WheelContents(MutableMapping):
-    def __init__(self, *, distr="foo", version="1.0", purelib=True):
+    def __init__(
+        self,
+        *,
+        distr="foo",
+        version="1.0",
+        purelib=True,
+        create_init=True,
+    ):
         self.distinfo = f"{distr}-{version}.dist-info"
         self.record_key = f"{self.distinfo}/RECORD"
         self._contents = {
-            f"{distr}/__init__.py": textwrap.dedent(
-                """\
-                    def main():
-                        print("Hello, World!")
-                """,
+            **(
+                {
+                    f"{distr}/__init__.py": textwrap.dedent(
+                        """\
+                            def main():
+                                print("Hello, World!")
+                        """,
+                    ),
+                }
+                if create_init
+                else {}
             ),
             f"{self.distinfo}/METADATA": textwrap.dedent(
                 f"""\

--- a/tests/integration/test_rpm_filelist.py
+++ b/tests/integration/test_rpm_filelist.py
@@ -1,0 +1,92 @@
+import compileall
+import shutil
+import subprocess
+import sysconfig
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from pyproject_installer.install_cmd import install_wheel
+
+RPMBUILD = shutil.which("rpmbuild")
+
+
+def make_spec(filelist_path):
+    return textwrap.dedent(
+        f"""\
+        %define _unpackaged_files_terminate_build 1
+        Name:    pyproject-installer-filelist-test
+        Version: 0.0
+        Release: 0
+        Summary: rpm filelist integration test
+        License: MIT
+        Group:   Development/Libraries
+        BuildArch: noarch
+
+        %description
+        Dummy package for rpmbuild -bl filelist validation.
+
+        %files -f {filelist_path}
+        """,
+    )
+
+
+@pytest.mark.skipif(
+    RPMBUILD is None,
+    reason="rpmbuild is not available on PATH",
+)
+def test_rpmbuild_bl_accepts_generated_filelist(
+    tmpdir,
+    wheel,
+    wheel_contents,
+):
+    contents = wheel_contents()
+    contents["foo/__init__.py"] = "def main():\n    return 0\n"
+    contents["foo/bar/__init__.py"] = "x = 1\n"
+    contents["foo_compat.py"] = "y = 2\n"
+    contents["foo-1.0.dist-info/entry_points.txt"] = textwrap.dedent(
+        """\
+        [console_scripts]
+        foo_cli = foo:main
+        """,
+    )
+    contents["foo-1.0.data/data/share/foo/asset.dat"] = "payload\n"
+
+    buildroot = tmpdir / "buildroot"
+    buildroot.mkdir()
+    filelist = tmpdir / "foo.files"
+
+    install_wheel(
+        wheel(contents=contents),
+        destdir=buildroot,
+        rpm_filelist=filelist,
+    )
+
+    purelib_buildroot = Path(
+        str(buildroot) + sysconfig.get_path("purelib"),
+    )
+    compileall.compile_dir(
+        str(purelib_buildroot),
+        optimize=[0, 1, 2],
+        quiet=1,
+    )
+
+    spec = tmpdir / "foo.spec"
+    spec.write_text(make_spec(filelist), encoding="utf-8")
+
+    # rpmbuild -bl validates %files against the buildroot.
+    # Exit code is 0 when every listed path exists in the buildroot.
+    subprocess.check_call(
+        [
+            RPMBUILD,
+            "--buildroot=" + str(buildroot),
+            "--define",
+            f"_topdir {tmpdir}",
+            "--nodeps",
+            "-bl",
+            str(spec),
+        ],
+        stderr=subprocess.STDOUT,
+    )
+    assert filelist.read_text().splitlines()

--- a/tests/unit/test_install/test_installer.py
+++ b/tests/unit/test_install/test_installer.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 import sysconfig
 import textwrap
+from importlib.util import cache_from_source
 from pathlib import Path
 from zipfile import ZipFile
 
@@ -17,6 +18,10 @@ from pyproject_installer.install_cmd._install import (
     get_installation_scheme,
 )
 from pyproject_installer.lib.scripts import SCRIPT_TEMPLATE
+
+
+def expected_pyc_lines(path):
+    return (cache_from_source(path, optimization=opt) for opt in ("", "1", "2"))
 
 
 class InstalledWheel:
@@ -735,3 +740,302 @@ def test_entry_points_scripts(
     )
     assert result.stdout == b"Hello, World!\n"
     assert result.stderr == b""
+
+
+def test_rpm_filelist_empty(wheel_contents, wheel, tmpdir):
+    """
+    Check rpm filelist for empty wheel.
+    """
+    contents = wheel_contents(create_init=False)
+    destdir = tmpdir / "destdir"
+    destdir.mkdir()
+    filelist = tmpdir / "foo.files"
+
+    install_wheel(
+        wheel(contents=contents),
+        destdir=destdir,
+        rpm_filelist=filelist,
+    )
+
+    recorded_files = filelist.read_text(encoding="utf-8").splitlines()
+    purelib = get_installation_scheme("foo")["purelib"]
+    expected_files = sorted(
+        (
+            f"%dir {purelib}/foo-1.0.dist-info",
+            f"{purelib}/foo-1.0.dist-info/METADATA",
+        ),
+    )
+    assert recorded_files == expected_files
+
+
+def test_rpm_filelist_entrypoints_scripts(wheel_contents, wheel, tmpdir):
+    """
+    Check if console script is recorded in rpm filelist.
+    """
+    contents = wheel_contents(create_init=False)
+    contents["foo-1.0.dist-info/entry_points.txt"] = (
+        "[console_scripts]\nbar = foo:main\n"
+    )
+    destdir = tmpdir / "destdir"
+    destdir.mkdir()
+    filelist = tmpdir / "foo.files"
+
+    install_wheel(
+        wheel(contents=contents),
+        destdir=destdir,
+        rpm_filelist=filelist,
+    )
+    recorded_files = filelist.read_text(encoding="utf-8").splitlines()
+    script_name = str(
+        Path(get_installation_scheme("foo")["scripts"]) / "bar",
+    )
+    purelib = get_installation_scheme("foo")["purelib"]
+    expected_files = sorted(
+        (
+            f"%dir {purelib}/foo-1.0.dist-info",
+            f"{purelib}/foo-1.0.dist-info/METADATA",
+            f"{purelib}/foo-1.0.dist-info/entry_points.txt",
+            script_name,
+        ),
+    )
+    assert recorded_files == expected_files
+
+
+def test_rpm_filelist_data(wheel_contents, wheel, tmpdir):
+    """
+    Check if data entries are recorded in rpm filelist.
+    """
+    contents = wheel_contents(create_init=False)
+    contents["foo-1.0.data/data/share/foo/asset.dat"] = ""
+    contents["foo-1.0.data/purelib/foo/purelib.foo.py"] = ""
+    contents["foo-1.0.data/platlib/foo/platlib.foo.py"] = ""
+    contents["foo-1.0.data/purelib/purelib.bar.py"] = ""
+    contents["foo-1.0.data/platlib/platlib.bar.py"] = ""
+    contents["foo-1.0.data/headers/foo.h"] = ""
+    contents["foo-1.0.data/headers/foo/bar.h"] = ""
+    contents["foo-1.0.data/scripts/foo"] = ""
+    destdir = tmpdir / "destdir"
+    destdir.mkdir()
+    filelist = tmpdir / "foo.files"
+
+    install_wheel(
+        wheel(contents=contents),
+        destdir=destdir,
+        rpm_filelist=filelist,
+    )
+
+    recorded_files = filelist.read_text(encoding="utf-8").splitlines()
+    purelib, platlib, headers, scripts, data = (
+        get_installation_scheme("foo")[name]
+        for name in ("purelib", "platlib", "headers", "scripts", "data")
+    )
+    expected_files = sorted(
+        (
+            f"%dir {headers}",
+            f"{headers}/foo.h",
+            f"%dir {headers}/foo",
+            f"{headers}/foo/bar.h",
+            f"%dir {purelib}/foo",
+            f"{purelib}/foo/purelib.foo.py",
+            f"%dir {purelib}/foo/__pycache__",
+            *expected_pyc_lines(f"{purelib}/foo/purelib.foo.py"),
+            f"{platlib}/foo/platlib.foo.py",
+            *expected_pyc_lines(f"{platlib}/foo/platlib.foo.py"),
+            f"{purelib}/purelib.bar.py",
+            *expected_pyc_lines(f"{purelib}/purelib.bar.py"),
+            f"{platlib}/platlib.bar.py",
+            *expected_pyc_lines(f"{platlib}/platlib.bar.py"),
+            f"%dir {purelib}/foo-1.0.dist-info",
+            f"{purelib}/foo-1.0.dist-info/METADATA",
+            f"{scripts}/foo",
+            f"{data}/share/foo/asset.dat",
+            *(
+                (f"%dir {platlib}/foo", f"%dir {platlib}/foo/__pycache__")
+                if purelib != platlib
+                else ()
+            ),
+        ),
+    )
+    assert recorded_files == expected_files
+
+
+def test_rpm_filelist_site(wheel_contents, wheel, tmpdir):
+    """
+    Check if site (purelib/platlib) entries are recorded in rpm filelist.
+    """
+    contents = wheel_contents()
+    contents["site_foo.py"] = ""
+    contents["foo/bar/__init__.py"] = ""
+    destdir = tmpdir / "destdir"
+    destdir.mkdir()
+    filelist = tmpdir / "foo.files"
+
+    install_wheel(
+        wheel(contents=contents),
+        destdir=destdir,
+        rpm_filelist=filelist,
+    )
+
+    recorded_files = filelist.read_text(encoding="utf-8").splitlines()
+    purelib = get_installation_scheme("foo")["purelib"]
+    expected_files = sorted(
+        (
+            f"%dir {purelib}/foo",
+            f"{purelib}/foo/__init__.py",
+            f"%dir {purelib}/foo/__pycache__",
+            *expected_pyc_lines(f"{purelib}/foo/__init__.py"),
+            f"%dir {purelib}/foo/bar",
+            f"{purelib}/foo/bar/__init__.py",
+            f"%dir {purelib}/foo/bar/__pycache__",
+            *expected_pyc_lines(f"{purelib}/foo/bar/__init__.py"),
+            f"{purelib}/site_foo.py",
+            *expected_pyc_lines(f"{purelib}/site_foo.py"),
+            f"%dir {purelib}/foo-1.0.dist-info",
+            f"{purelib}/foo-1.0.dist-info/METADATA",
+        ),
+    )
+    assert recorded_files == expected_files
+
+
+def test_rpm_filelist_not_used(wheel_contents, wheel, tmpdir):
+    """
+    Check if rpm filelist is not generated if was not asked
+    """
+    contents = wheel_contents()
+    destdir = tmpdir / "destdir"
+    destdir.mkdir()
+    filelist = tmpdir / "foo.files"
+
+    install_wheel(wheel(contents=contents), destdir=destdir)
+
+    assert not filelist.exists()
+
+
+def test_rpm_filelist_installer(wheel_contents, wheel, tmpdir):
+    """
+    Check if INSTALLER in rpm filelist if used
+    """
+    contents = wheel_contents(create_init=False)
+    destdir = tmpdir / "destdir"
+    destdir.mkdir()
+    filelist = tmpdir / "foo.files"
+
+    install_wheel(
+        wheel(contents=contents),
+        destdir=destdir,
+        installer="test_installer",
+        rpm_filelist=filelist,
+    )
+
+    recorded_files = filelist.read_text(encoding="utf-8").splitlines()
+    purelib = get_installation_scheme("foo")["purelib"]
+    expected_files = sorted(
+        (
+            f"%dir {purelib}/foo-1.0.dist-info",
+            f"{purelib}/foo-1.0.dist-info/METADATA",
+            f"{purelib}/foo-1.0.dist-info/INSTALLER",
+        ),
+    )
+    assert recorded_files == expected_files
+
+
+def test_rpm_filelist_no_strip_dist_info(wheel_contents, wheel, tmpdir):
+    """
+    Check if PEP 639 licenses/ in rpm filelist with --no-strip-dist-info
+    """
+    contents = wheel_contents(create_init=False)
+    contents["foo-1.0.dist-info/licenses/LICENSE.txt"] = "MIT\n"
+    destdir = tmpdir / "destdir"
+    destdir.mkdir()
+    filelist = tmpdir / "foo.files"
+
+    install_wheel(
+        wheel(contents=contents),
+        destdir=destdir,
+        rpm_filelist=filelist,
+        strip_dist_info=False,
+    )
+
+    recorded_files = filelist.read_text(encoding="utf-8").splitlines()
+    purelib = get_installation_scheme("foo")["purelib"]
+    expected_files = sorted(
+        (
+            f"%dir {purelib}/foo-1.0.dist-info",
+            f"{purelib}/foo-1.0.dist-info/METADATA",
+            f"{purelib}/foo-1.0.dist-info/WHEEL",
+            f"%dir {purelib}/foo-1.0.dist-info/licenses",
+            f"{purelib}/foo-1.0.dist-info/licenses/LICENSE.txt",
+        ),
+    )
+    assert recorded_files == expected_files
+
+
+def test_rpm_filelist_man_page_globbing(wheel_contents, wheel, tmpdir):
+    """
+    Check man page globbing in rpm flielist.
+    """
+    contents = wheel_contents(create_init=False)
+    contents["foo-1.0.data/data/share/man/man1/aaa.1"] = ""
+    contents["foo-1.0.data/data/share/man/man1/bbb.1.gz"] = ""
+    contents["foo-1.0.data/data/share/man/man1/ccc.1.bz2"] = ""
+    contents["foo-1.0.data/data/share/man/man1/ddd.1.Z"] = ""
+    contents["foo-1.0.data/data/share/man/man1/eee.1.xz"] = ""
+    contents["foo-1.0.data/data/share/man/man1/fff.1.zst"] = ""
+    contents["foo-1.0.data/data/share/man/man3/Baz.3pm"] = ""
+    contents["foo-1.0.data/data/share/man/man3/Qux.3pm.gz"] = ""
+    destdir = tmpdir / "destdir"
+    destdir.mkdir()
+    filelist = tmpdir / "foo.files"
+
+    install_wheel(
+        wheel(contents=contents),
+        destdir=destdir,
+        rpm_filelist=filelist,
+    )
+
+    recorded_files = filelist.read_text(encoding="utf-8").splitlines()
+    purelib = get_installation_scheme("foo")["purelib"]
+    data = get_installation_scheme("foo")["data"]
+    expected_files = sorted(
+        (
+            f"%dir {purelib}/foo-1.0.dist-info",
+            f"{purelib}/foo-1.0.dist-info/METADATA",
+            f"{data}/share/man/man1/aaa.1*",
+            f"{data}/share/man/man1/bbb.1*",
+            f"{data}/share/man/man1/ccc.1*",
+            f"{data}/share/man/man1/ddd.1*",
+            f"{data}/share/man/man1/eee.1.xz*",
+            f"{data}/share/man/man1/fff.1.zst*",
+            f"{data}/share/man/man3/Baz.3pm*",
+            f"{data}/share/man/man3/Qux.3pm*",
+        ),
+    )
+    assert recorded_files == expected_files
+
+
+def test_rpm_filelist_sys_pycache_prefix(
+    wheel_contents,
+    wheel,
+    tmpdir,
+    mocker,
+):
+    """
+    Check the error if sys.pycache_prefix is set
+    """
+    contents = wheel_contents(create_init=False)
+    destdir = tmpdir / "destdir"
+    destdir.mkdir()
+    filelist = tmpdir / "foo.files"
+
+    mocker.patch(
+        "pyproject_installer.install_cmd._install.sys.pycache_prefix",
+        "/new_prefix",
+    )
+    error_pattern = "rpm-filelist requires sys.pycache_prefix to be at its"
+    with pytest.raises(ValueError, match=error_pattern):
+        install_wheel(
+            wheel(contents=contents),
+            destdir=destdir,
+            rpm_filelist=filelist,
+        )
+    assert not filelist.exists()

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -340,6 +340,7 @@ def test_install_cli_default(mock_install_wheel, mock_read_tracker):
         "destdir": destdir,
         "installer": None,
         "strip_dist_info": True,
+        "rpm_filelist": None,
     }
 
     project_main.main(install_args)
@@ -359,6 +360,7 @@ def test_install_cli_destdir(mock_install_wheel, mock_read_tracker):
         "destdir": destdir,
         "installer": None,
         "strip_dist_info": True,
+        "rpm_filelist": None,
     }
 
     project_main.main(install_args)
@@ -377,6 +379,7 @@ def test_install_cli_wheel(mock_install_wheel, mock_read_tracker):
         "destdir": destdir,
         "installer": None,
         "strip_dist_info": True,
+        "rpm_filelist": None,
     }
 
     project_main.main(install_args)
@@ -395,6 +398,7 @@ def test_install_cli_wheel_destdir(mock_install_wheel, mock_read_tracker):
         "destdir": destdir,
         "installer": None,
         "strip_dist_info": True,
+        "rpm_filelist": None,
     }
 
     project_main.main(install_args)
@@ -414,6 +418,7 @@ def test_install_cli_installer_tool(mock_install_wheel, mock_read_tracker):
         "destdir": destdir,
         "installer": installer_tool,
         "strip_dist_info": True,
+        "rpm_filelist": None,
     }
 
     project_main.main(install_args)
@@ -433,6 +438,7 @@ def test_install_cli_no_strip_dist_info(mock_install_wheel):
         "destdir": destdir,
         "installer": None,
         "strip_dist_info": False,
+        "rpm_filelist": None,
     }
 
     project_main.main(install_args)
@@ -451,6 +457,28 @@ def test_install_default_wheel_missing_tracker(mock_read_tracker, capsys):
     assert not captured.out
     expected_msg = "Missing wheel tracker, re-run build steps or specify wheel"
     assert expected_msg in captured.err
+
+
+@pytest.mark.usefixtures("mock_read_tracker")
+def test_install_cli_rpm_filelist(mock_install_wheel, tmpdir):
+    """
+    Run install with --rpm-filelist.
+    """
+    filelist = tmpdir / "foo.files"
+    install_args = ("install", "--rpm-filelist", str(filelist))
+
+    destdir = Path("/")
+    wheel = Path.cwd() / "dist" / "foo.whl"
+    i_args = (wheel,)
+    i_kwargs = {
+        "destdir": destdir,
+        "installer": None,
+        "strip_dist_info": True,
+        "rpm_filelist": filelist,
+    }
+
+    project_main.main(install_args)
+    mock_install_wheel.assert_called_once_with(*i_args, **i_kwargs)
 
 
 def test_run_cli_default(mock_run_command, mock_read_tracker, caplog):


### PR DESCRIPTION
Opt-in `install --rpm-filelist PATH` writes an RPM %files-compatible filelist of every installed file plus computed PEP 3147/488 .pyc paths for each .py under purelib/platlib. A spec can then consume it via `%files -f dist/foo.files` instead of enumerating contents by hand.

%dir ownership: dist-info always; headers scheme dir only when occupied; intermediates under purelib/platlib plus their __pycache__ siblings. Site roots and FHS roots under scheme["scripts"] / scheme["data"] are never emitted.

Requires sys.pycache_prefix at its default (None).

Fixes: https://github.com/stanislavlevin/pyproject_installer/issues/142

## Summary by Sourcery

Add an opt-in --rpm-filelist install option that records installed files and computed .pyc paths for RPM %files consumption, integrate it into the CLI and installer, and document its behavior.

New Features:
- Introduce the --rpm-filelist PATH flag to the install CLI to generate an RPM %files-compatible file list for all installed files plus relevant .pyc paths.
- Track installed files during wheel extraction, entrypoint script generation, and .data relocation to support file list generation.
- Provide a helper module to render and write RPM-compatible file lists, including .pyc expansion and man-page globbing semantics.

Enhancements:
- Refine wheel data handling by naming the .data directory via WheelFile.data_name and passing installed path tracking into data installation and entrypoint script generation.

Documentation:
- Document the --rpm-filelist option in the README with detailed semantics, examples, and constraints, and add a design document describing the motivation and specification of the feature.

Tests:
- Add unit tests covering rpm_filelist behavior across empty wheels, entry points, data files, site packages, INSTALLER files, no-strip-dist-info mode, man-page handling, and sys.pycache_prefix constraints.
- Add a CLI test ensuring the install subcommand forwards the --rpm-filelist argument to install_wheel.
- Add an integration test that validates the generated file list against rpmbuild -bl.