### PR TITLE
employ `packaging` for parsing dependency groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,8 @@ backend-path = ["."]
 
 [dependency-groups]
 test = [
-    "pytest",
+    # 8.4.0 added pytest.RaisesGroup, used for ExceptionGroup assertions.
+    "pytest >= 8.4.0",
     "pytest-mock",
 ]
 coverage = [

--- a/src/pyproject_installer/deps_cmd/collectors/pep735.py
+++ b/src/pyproject_installer/deps_cmd/collectors/pep735.py
@@ -1,12 +1,14 @@
 from pathlib import Path
 
-from ...lib import is_pep508_requirement, tomllib
-from ...lib.normalization import pep503_normalized_name
+from ...lib import dependency_groups, errors, requirements, tomllib
 from .collector import Collector
 
 
 class Pep735Collector(Collector):
-    """Collect dependencies specified by Dependency Group according to PEP735
+    """Collect dependencies specified by Dependency Group according to PEP735.
+
+    Parsing, name normalization, include resolution, cycle detection, and
+    PEP 508 validation are delegated to packaging.dependency_groups.
 
     Specification:
     - https://peps.python.org/pep-0735/#specification
@@ -17,7 +19,6 @@ class Pep735Collector(Collector):
     def __init__(self, group):
         # group name can be non-normalized
         self.group = group
-        self._groups_data = None
 
     def collect(self):
         pyproject_file = Path.cwd() / "pyproject.toml"
@@ -27,119 +28,38 @@ class Pep735Collector(Collector):
 
         table_name = "dependency-groups"
         try:
-            self._groups_data = pyproject_data[table_name]
+            groups_data = pyproject_data[table_name]
         except KeyError:
             raise ValueError(
-                f"pep735: missing {table_name} table in {pyproject_file.name}",
+                f"{self.name}: missing {table_name} table in "
+                f"{pyproject_file.name}",
             ) from None
 
-        if not isinstance(self._groups_data, dict):
+        if not isinstance(groups_data, dict):
             raise TypeError(
-                "pep735: Dependency Groups is not a dict: "
-                f"{self._groups_data!r}",
+                f"{self.name}: Dependency Groups is not a dict: "
+                f"{groups_data!r}",
             )
 
-        return self._resolve_dep_group(group_name=self.group)
-
-    def _resolve_group_name(self, group_name, include_chain):
-        """Resolve actual group's name"""
-        # config group names can be non-normalized and duplicated
-        group_nname = pep503_normalized_name(group_name)
-        actual_group_names = sorted(
-            (
-                gp_name
-                for gp_name in self._groups_data
-                if pep503_normalized_name(gp_name) == group_nname
-            ),
-        )
-
-        if not actual_group_names:
-            raise ValueError(
-                "pep735: group dependencies are not configured ("
-                f"group: {group_name}, "
-                f"include chain: {'->'.join(include_chain)})",
+        try:
+            return dependency_groups.resolve_dependency_groups(
+                groups_data,
+                self.group,
             )
-        if len(actual_group_names) > 1:
-            raise ValueError(
-                "pep735: duplicate group names ("
-                f"group: {group_name}, "
-                f"include chain: {'->'.join(include_chain)}"
-                f"): {', '.join(actual_group_names)}",
-            )
-
-        (group_cname,) = actual_group_names
-        return group_cname
-
-    def _resolve_dep_group(self, group_name, visited_groups=()):
-        """Recursively resolve Dependency Group's dependencies"""
-        resolved_group_name = self._resolve_group_name(
-            group_name,
-            (*visited_groups, group_name) if visited_groups else (),
-        )
-        include_chain = (
-            (*visited_groups, resolved_group_name) if visited_groups else ()
-        )
-
-        group_nname = pep503_normalized_name(group_name)
-        if group_nname in map(pep503_normalized_name, visited_groups):
-            raise ValueError(
-                "pep735: include cycle detected ("
-                f"group: {resolved_group_name}, "
-                f"include chain: {'->'.join(include_chain)})",
-            )
-
-        deps_data = self._groups_data[resolved_group_name]
-        if not isinstance(deps_data, list):
-            raise TypeError(
-                "pep735: dependencies format is not a list ("
-                f"group: {resolved_group_name}, "
-                f"include chain: {'->'.join(include_chain)}"
-                f"): {deps_data!r}",
-            )
-
-        for dep in deps_data:
-            if isinstance(dep, str):
-                # must be a valid PEP508 Dependency Specifier
-                if not is_pep508_requirement(dep):
-                    err_msg = (
-                        "pep735: invalid PEP508 Dependency Specifier ("
-                        f"group: {resolved_group_name}, "
-                        f"include chain: {'->'.join(include_chain)}"
-                        f"): {dep}"
-                    )
-                    raise ValueError(err_msg) from None
-                yield dep
-            elif isinstance(dep, dict):
-                if dep.keys() != {"include-group"}:
-                    err_msg = (
-                        "pep735: invalid Dependency Object Specifier ("
-                        f"group: {resolved_group_name}, "
-                        f"include chain: {'->'.join(include_chain)}"
-                        f"): {dep!r}"
-                    )
-                    raise ValueError(err_msg)
-
-                include_group = dep["include-group"]
-                if not isinstance(include_group, str):
-                    err_msg = (
-                        "pep735: Dependency Group Include's value is not a "
-                        "string ("
-                        f"group: {resolved_group_name}, "
-                        f"include chain: {'->'.join(include_chain)}"
-                        f"): {include_group!r}"
-                    )
-                    raise TypeError(err_msg)
-
-                yield from self._resolve_dep_group(
-                    group_name=include_group,
-                    visited_groups=(*visited_groups, resolved_group_name),
-                )
-            else:
-                err_msg = (
-                    "pep735: dependencies lists may contain strings or "
-                    f"dicts ("
-                    f"group: {resolved_group_name}, "
-                    f"include chain: {'->'.join(include_chain)}"
-                    f"): {dep!r}"
-                )
-                raise TypeError(err_msg)
+        except errors.ExceptionGroup as eg:
+            # Packaging's resolver accumulates per-item errors and
+            # surfaces them as a single ExceptionGroup, so one bad
+            # config may carry several inner exceptions. Re-raise
+            # as a fresh group with our prefix on the outer
+            # message; inner exceptions are preserved as-is.
+            raise errors.ExceptionGroup(
+                f"{self.name}: {eg.message}",
+                eg.exceptions,
+            ) from None
+        except requirements.InvalidRequirement as e:
+            raise ValueError(f"{self.name}: {e}") from None
+        except TypeError as e:
+            # Raised when an `include-group` value is not a string:
+            # packaging propagates this raw rather than collecting
+            # it into the ExceptionGroup above.
+            raise TypeError(f"{self.name}: {e}") from None

--- a/src/pyproject_installer/lib/__init__.py
+++ b/src/pyproject_installer/lib/__init__.py
@@ -6,9 +6,17 @@ try:
 except ModuleNotFoundError:
     from .._vendor import tomli as tomllib
 
-from .._vendor.packaging import markers, requirements, specifiers
+from .._vendor.packaging import (
+    dependency_groups,
+    errors,
+    markers,
+    requirements,
+    specifiers,
+)
 
 __all__ = [
+    "dependency_groups",
+    "errors",
     "is_pep508_requirement",
     "markers",
     "requirements",

--- a/src/pyproject_installer/lib/__init__.py
+++ b/src/pyproject_installer/lib/__init__.py
@@ -12,6 +12,7 @@ from .._vendor.packaging import (
     markers,
     requirements,
     specifiers,
+    utils,
 )
 
 __all__ = [
@@ -22,6 +23,7 @@ __all__ = [
     "requirements",
     "specifiers",
     "tomllib",
+    "utils",
 ]
 
 

--- a/src/pyproject_installer/lib/normalization.py
+++ b/src/pyproject_installer/lib/normalization.py
@@ -1,4 +1,4 @@
-import re
+from . import utils
 
 
 def pep503_normalized_name(name):
@@ -6,4 +6,4 @@ def pep503_normalized_name(name):
     PEP503 normalized names
     https://peps.python.org/pep-0503/#normalized-names
     """
-    return re.sub(r"[-_.]+", "-", name).lower()
+    return utils.canonicalize_name(name)

--- a/tests/unit/test_deps/test_collectors/test_pep735.py
+++ b/tests/unit/test_deps/test_collectors/test_pep735.py
@@ -1,10 +1,63 @@
 import json
 import re
+import sys
 from copy import deepcopy
 
 import pytest
 
 from pyproject_installer.deps_cmd import deps_command
+from pyproject_installer.lib import dependency_groups
+
+if sys.version_info >= (3, 11):
+    RaisesGroup = pytest.RaisesGroup
+else:
+    from pyproject_installer.lib import errors
+
+    class RaisesGroup:
+        """Python-3.10 fallback for ``pytest.RaisesGroup``.
+
+        On 3.10 ``packaging.errors.ExceptionGroup`` is a plain ``Exception``
+        subclass (PEP 654 lands in 3.11), so ``pytest.RaisesGroup`` — which
+        does ``isinstance(exc, BaseExceptionGroup)`` — refuses to match.
+        This shim asserts the same shape (one ``ExceptionGroup`` whose
+        ``.exceptions`` are positionally instances of the given types and
+        whose ``.message`` matches ``match``) using only the attributes
+        packaging's shim provides.
+        """
+
+        def __init__(self, *expected_types, match=None):
+            self._expected_types = expected_types
+            self._match = match
+            self._cm = pytest.raises(errors.ExceptionGroup)
+            self._info = None
+
+        def __enter__(self):
+            self._info = self._cm.__enter__()
+            return self
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            handled = self._cm.__exit__(exc_type, exc_val, exc_tb)
+            eg = self._info.value
+            if self._match is not None:
+                matched = re.search(self._match, eg.message)
+                assert (
+                    matched
+                ), f"message {eg.message!r} does not match {self._match!r}"
+            actual = list(eg.exceptions)
+            assert len(actual) == len(self._expected_types), (
+                f"got {len(actual)} inner exceptions, "
+                f"expected {len(self._expected_types)}"
+            )
+            for got, expected in zip(
+                actual,
+                self._expected_types,
+                strict=True,
+            ):
+                assert isinstance(got, expected), (
+                    f"inner exception {got!r} is not an instance of "
+                    f"{expected!r}"
+                )
+            return handled
 
 
 @pytest.fixture
@@ -138,12 +191,9 @@ def test_pep735_collector_no_groups(pep735_deps, pep735_depsconfig):
     pep735_deps({})
     depsconfig_path, input_conf = pep735_depsconfig()
 
-    expected_err = re.escape(
-        "pep735: group dependencies are not configured ("
-        "group: test, include chain: )",
-    )
-    expected_err = f"^{expected_err}$"
-    with pytest.raises(ValueError, match=expected_err):
+    expected_err = re.escape("pep735: ")
+    expected_err = f"^{expected_err}"
+    with RaisesGroup(LookupError, match=expected_err):
         deps_command("sync", depsconfig_path, srcnames=[])
 
     actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))
@@ -153,18 +203,12 @@ def test_pep735_collector_no_groups(pep735_deps, pep735_depsconfig):
 @pytest.mark.parametrize(
     "group_data",
     (
-        ({"gp1": []}, "group: test, include chain: "),
-        (
-            {"teSt": ['{include-group = "gP1"}']},
-            "group: gP1, include chain: teSt->gP1",
-        ),
-        (
-            {
-                "gP1": ['{include-group = "gP2"}'],
-                "teSt": ['{include-group = "Gp1"}'],
-            },
-            "group: gP2, include chain: teSt->gP1->gP2",
-        ),
+        {"gp1": []},
+        {"teSt": ['{include-group = "gP1"}']},
+        {
+            "gP1": ['{include-group = "gP2"}'],
+            "teSt": ['{include-group = "Gp1"}'],
+        },
     ),
 )
 def test_pep735_collector_missing_group(
@@ -175,15 +219,12 @@ def test_pep735_collector_missing_group(
     """
     Collection of PEP735 dependencies with missing group
     """
-    group_config, err_msg = group_data
-    pep735_deps(group_config)
+    pep735_deps(group_data)
     depsconfig_path, input_conf = pep735_depsconfig()
 
-    expected_err = re.escape(
-        f"pep735: group dependencies are not configured ({err_msg})",
-    )
-    expected_err = f"^{expected_err}$"
-    with pytest.raises(ValueError, match=expected_err):
+    expected_err = re.escape("pep735: ")
+    expected_err = f"^{expected_err}"
+    with RaisesGroup(LookupError, match=expected_err):
         deps_command("sync", depsconfig_path, srcnames=[])
 
     actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))
@@ -193,23 +234,14 @@ def test_pep735_collector_missing_group(
 @pytest.mark.parametrize(
     "group_data",
     (
-        (
-            {"tesT": [], "Test": []},
-            "(group: test, include chain: ): Test, tesT",
-        ),
-        (
-            {"gRp": [], "Grp": [], "teSt": ['{include-group = "grP"}']},
-            "(group: grP, include chain: teSt->grP): Grp, gRp",
-        ),
-        (
-            {
-                "gRp1": ['{include-group = "grP2"}'],
-                "Grp2": [],
-                "gRp2": [],
-                "teSt": ['{include-group = "grP1"}'],
-            },
-            "(group: grP2, include chain: teSt->gRp1->grP2): Grp2, gRp2",
-        ),
+        {"tesT": [], "Test": []},
+        {"gRp": [], "Grp": [], "teSt": ['{include-group = "grP"}']},
+        {
+            "gRp1": ['{include-group = "grP2"}'],
+            "Grp2": [],
+            "gRp2": [],
+            "teSt": ['{include-group = "grP1"}'],
+        },
     ),
 )
 def test_pep735_collector_duplicate_names(
@@ -220,13 +252,15 @@ def test_pep735_collector_duplicate_names(
     """
     Collection of PEP735 dependencies with duplicate group names
     """
-    group_config, err_msg = group_data
-    pep735_deps(group_config)
+    pep735_deps(group_data)
     depsconfig_path, input_conf = pep735_depsconfig()
 
-    expected_err = re.escape(f"pep735: duplicate group names {err_msg}")
-    expected_err = f"^{expected_err}$"
-    with pytest.raises(ValueError, match=expected_err):
+    expected_err = re.escape("pep735: ")
+    expected_err = f"^{expected_err}"
+    with RaisesGroup(
+        dependency_groups.DuplicateGroupNames,
+        match=expected_err,
+    ):
         deps_command("sync", depsconfig_path, srcnames=[])
 
     actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))
@@ -234,40 +268,31 @@ def test_pep735_collector_duplicate_names(
 
 
 @pytest.mark.parametrize(
-    "group_data",
+    "group_config",
     (
-        (["tesT = true"], "group: tesT, include chain: "),
-        (
-            ["gRp = true", 'teSt = [{include-group = "grP"}]'],
-            "group: gRp, include chain: teSt->gRp",
-        ),
-        (
-            [
-                'gRp1 = [{include-group = "grP2"}]',
-                "gRp2 = true",
-                'teSt = [{include-group = "grP1"}]',
-            ],
-            "group: gRp2, include chain: teSt->gRp1->gRp2",
-        ),
+        ["tesT = true"],
+        ["gRp = true", 'teSt = [{include-group = "grP"}]'],
+        [
+            'gRp1 = [{include-group = "grP2"}]',
+            "gRp2 = true",
+            'teSt = [{include-group = "grP1"}]',
+        ],
     ),
 )
 def test_pep735_collector_invalid_type_groupdeps(
     pyproject_toml,
     pep735_depsconfig,
-    group_data,
+    group_config,
 ):
     """
     Collection of PEP735 dependencies with invalid type of group's value
     """
-    group_config, err_msg = group_data
     pyproject_toml("\n".join(("[dependency-groups]", *group_config)) + "\n")
     depsconfig_path, input_conf = pep735_depsconfig()
 
-    expected_err = re.escape(
-        f"pep735: dependencies format is not a list ({err_msg}): ",
-    )
+    expected_err = re.escape("pep735: ")
     expected_err = f"^{expected_err}"
-    with pytest.raises(TypeError, match=expected_err):
+    with RaisesGroup(TypeError, match=expected_err):
         deps_command("sync", depsconfig_path, srcnames=[])
 
     actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))
@@ -277,20 +302,14 @@ def test_pep735_collector_invalid_type_groupdeps(
 @pytest.mark.parametrize(
     "group_data",
     (
-        ({"tesT": ["true"]}, "group: tesT, include chain: "),
-        ({"tesT": ['"foo"', "true"]}, "group: tesT, include chain: "),
-        (
-            {"gRp": ["true"], "teSt": ['{include-group = "grP"}']},
-            "group: gRp, include chain: teSt->gRp",
-        ),
-        (
-            {
-                "gRp1": ['{include-group = "grP2"}'],
-                "Grp2": ["true"],
-                "teSt": ['{include-group = "grP1"}'],
-            },
-            "group: Grp2, include chain: teSt->gRp1->Grp2",
-        ),
+        {"tesT": ["true"]},
+        {"tesT": ['"foo"', "true"]},
+        {"gRp": ["true"], "teSt": ['{include-group = "grP"}']},
+        {
+            "gRp1": ['{include-group = "grP2"}'],
+            "Grp2": ["true"],
+            "teSt": ['{include-group = "grP1"}'],
+        },
     ),
 )
 def test_pep735_collector_invalid_type_depslist(
@@ -304,17 +323,35 @@ def test_pep735_collector_invalid_type_depslist(
     Requirement lists under dependency-groups may contain strings, tables
     (“dicts” in Python), or a mix of strings and tables.
     """
-    group_config, err_msg = group_data
-
-    pep735_deps(group_config)
+    pep735_deps(group_data)
     depsconfig_path, input_conf = pep735_depsconfig()
 
-    expected_err = re.escape(
-        "pep735: dependencies lists may contain strings or dicts "
-        f"({err_msg}): ",
-    )
+    expected_err = re.escape("pep735: ")
     expected_err = f"^{expected_err}"
-    with pytest.raises(TypeError, match=expected_err):
+    with RaisesGroup(TypeError, match=expected_err):
+        deps_command("sync", depsconfig_path, srcnames=[])
+
+    actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))
+    assert actual_conf == input_conf
+
+
+def test_pep735_collector_multiple_errors_in_exceptiongroup(
+    pep735_deps,
+    pep735_depsconfig,
+):
+    """
+    Collection of PEP735 dependencies with several errors in one group
+
+    Packaging accumulates per-item errors and surfaces them together as one
+    ExceptionGroup; the wrap preserves every inner exception and prepends
+    'pep735: ' to the group's outer message.
+    """
+    pep735_deps({"test": ["true", "false"]})
+    depsconfig_path, input_conf = pep735_depsconfig()
+
+    expected_err = re.escape("pep735: ")
+    expected_err = f"^{expected_err}"
+    with RaisesGroup(TypeError, TypeError, match=expected_err):
         deps_command("sync", depsconfig_path, srcnames=[])
 
     actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))
@@ -348,12 +385,8 @@ def test_pep735_collector_valid_pep508_deps(
 @pytest.mark.parametrize(
     "group_data",
     (
-        ({"tesT": None}, "tesT", "group: tesT, include chain: "),
-        (
-            {"gRp": None, "teSt": ['{include-group = "grP"}']},
-            "gRp",
-            "group: gRp, include chain: teSt->gRp",
-        ),
+        ({"tesT": None}, "tesT"),
+        ({"gRp": None, "teSt": ['{include-group = "grP"}']}, "gRp"),
         (
             {
                 "gRp1": ['{include-group = "grP2"}'],
@@ -361,7 +394,6 @@ def test_pep735_collector_valid_pep508_deps(
                 "teSt": ['{include-group = "grP1"}'],
             },
             "Grp2",
-            "group: Grp2, include chain: teSt->gRp1->Grp2",
         ),
     ),
 )
@@ -377,15 +409,13 @@ def test_pep735_collector_invalid_pep508_deps(
     Strings in requirement lists must be valid Dependency Specifiers, as defined
     in PEP 508.
     """
-    group_config, group, err_msg = group_data
+    group_config, group = group_data
     in_reqs, _ = invalid_pep508_data
 
     pep735_deps(group_config | {group: [f'"{x}"' for x in in_reqs]})
     depsconfig_path, input_conf = pep735_depsconfig()
 
-    expected_err = re.escape(
-        f"pep735: invalid PEP508 Dependency Specifier ({err_msg}): ",
-    )
+    expected_err = re.escape("pep735: ")
     expected_err = f"^{expected_err}"
     with pytest.raises(ValueError, match=expected_err):
         deps_command("sync", depsconfig_path, srcnames=[])
@@ -433,7 +463,6 @@ def test_pep735_collector_no_deps(pep735_deps, pep735_depsconfig, group_data):
             {"gp1": ['{foo = "bar"}'], "gp2": ['"_foo"'], "test": ['"foo"']},
             ["foo"],
         ),
-        ({"test": ['"foo"'], "gp1": ['"foo1"'], "gP1": ['"foo2"']}, ["foo"]),
         ({"gp1": ['{include-group = "gp2"}'], "test": ['"foo"']}, ["foo"]),
     ),
 )
@@ -487,12 +516,12 @@ def test_pep735_collector_invalid_dep_object_specifiers(
     pep735_deps({group: invalid_deps})
     depsconfig_path, input_conf = pep735_depsconfig(group)
 
-    expected_err = re.escape(
-        "pep735: invalid Dependency Object Specifier ("
-        f"group: {group}, include chain: ): ",
-    )
+    expected_err = re.escape("pep735: ")
     expected_err = f"^{expected_err}"
-    with pytest.raises(ValueError, match=expected_err):
+    with RaisesGroup(
+        dependency_groups.InvalidDependencyGroupObject,
+        match=expected_err,
+    ):
         deps_command("sync", depsconfig_path, srcnames=[])
 
     actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))
@@ -523,10 +552,7 @@ def test_pep735_collector_invalid_dep_group_include(
     pep735_deps({group: invalid_deps})
     depsconfig_path, input_conf = pep735_depsconfig(group)
 
-    expected_err = re.escape(
-        "pep735: Dependency Group Include's value is not a string ("
-        f"group: {group}, include chain: ): ",
-    )
+    expected_err = re.escape("pep735: ")
     expected_err = f"^{expected_err}"
     with pytest.raises(TypeError, match=expected_err):
         deps_command("sync", depsconfig_path, srcnames=[])
@@ -538,33 +564,19 @@ def test_pep735_collector_invalid_dep_group_include(
 @pytest.mark.parametrize(
     "group_data",
     (
-        (
-            {
-                "teSt": ['{include-group = "Test"}'],
-            },
-            "group: teSt, include chain: teSt->teSt",
-        ),
-        (
-            {
-                "gRp1": ['{include-group = "Test"}'],
-                "teSt": ['{include-group = "grP1"}'],
-            },
-            "group: teSt, include chain: teSt->gRp1->teSt",
-        ),
-        (
-            {
-                "gRp1": ['{include-group = "Grp1"}'],
-                "teSt": ['{include-group = "grP1"}'],
-            },
-            "group: gRp1, include chain: teSt->gRp1->gRp1",
-        ),
-        (
-            {
-                "gRp1": ['"b"', '{include-group = "Test"}'],
-                "teSt": ['"a"', '{include-group = "grP1"}'],
-            },
-            "group: teSt, include chain: teSt->gRp1->teSt",
-        ),
+        {"teSt": ['{include-group = "Test"}']},
+        {
+            "gRp1": ['{include-group = "Test"}'],
+            "teSt": ['{include-group = "grP1"}'],
+        },
+        {
+            "gRp1": ['{include-group = "Grp1"}'],
+            "teSt": ['{include-group = "grP1"}'],
+        },
+        {
+            "gRp1": ['"b"', '{include-group = "Test"}'],
+            "teSt": ['"a"', '{include-group = "grP1"}'],
+        },
     ),
 )
 def test_pep735_collector_include_cycle(
@@ -575,15 +587,15 @@ def test_pep735_collector_include_cycle(
     """
     Collection of PEP735 dependencies with include cycle
     """
-    group_config, err_msg = group_data
-    pep735_deps(group_config)
+    pep735_deps(group_data)
     depsconfig_path, input_conf = pep735_depsconfig()
 
-    expected_err = re.escape(
-        f"pep735: include cycle detected ({err_msg})",
-    )
-    expected_err = f"^{expected_err}$"
-    with pytest.raises(ValueError, match=expected_err):
+    expected_err = re.escape("pep735: ")
+    expected_err = f"^{expected_err}"
+    with RaisesGroup(
+        dependency_groups.CyclicDependencyGroup,
+        match=expected_err,
+    ):
         deps_command("sync", depsconfig_path, srcnames=[])
 
     actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))


### PR DESCRIPTION
- delegate PEP 735 parsing to `packaging.dependency_groups` (vendored at packaging 26.1+), reached via `pyproject_installer.lib`
- delegate `pep503_normalized_name` to `packaging.utils`
    
Fixes: https://github.com/stanislavlevin/pyproject_installer/issues/141

## Summary by Sourcery

Delegate PEP 735 dependency-group resolution and name normalization to vendored packaging while adjusting error handling to surface packaging’s structured exceptions.

New Features:
- Support packaging.dependency_groups-based resolution of dependency groups during PEP 735 dependency collection.

Bug Fixes:
- Preserve and expose multiple per-item dependency-group validation errors via ExceptionGroup rather than failing on the first error.
- Use packaging’s canonical name normalization to align dependency-group name handling with packaging’s semantics.

Enhancements:
- Simplify the PEP 735 collector by removing custom resolution logic in favor of packaging’s dependency_groups resolver.
- Relax tests to assert on generic pep735-prefixed error messages and specific exception types instead of bespoke, fully formatted messages.

Tests:
- Update PEP 735 collector tests to expect ExceptionGroup-based failures and packaging-specific error types, and add coverage for multiple errors within a single exception group.