### PR TITLE
feat(install): add --platlib/--purelib install flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,22 @@ python -m pyproject_installer install
 > /usr/share/foo/asset.dat
 > ```
 
+> **`--platlib`**
+>
+> Force the install to land in the `platlib` site-packages directory regardless of the wheel's `Root-Is-Purelib` flag. Both the unprefixed wheel root and any `.data/purelib/` content are redirected to `platlib`. Mutually exclusive with `--purelib`.
+>
+> *Default:* unset, the wheel's `Root-Is-Purelib` flag is honoured
+>
+> *Example:* `python -m pyproject_installer install --destdir /tmp/buildroot --platlib`
+
+> **`--purelib`**
+>
+> Force the install to land in the `purelib` site-packages directory regardless of the wheel's `Root-Is-Purelib` flag. Both the unprefixed wheel root and any `.data/platlib/` content are redirected to `purelib`. Mutually exclusive with `--platlib`. The symmetric inverse of `--platlib`.
+>
+> *Default:* unset, the wheel's `Root-Is-Purelib` flag is honoured
+>
+> *Example:* `python -m pyproject_installer install --destdir /tmp/buildroot --purelib`
+
 ### Run
 
 Run command within Python virtual environment that has access to system and user

--- a/docs/designs/platlib_purelib_options.md
+++ b/docs/designs/platlib_purelib_options.md
@@ -1,0 +1,101 @@
+## Abstract
+This RFE proposes two new mutually-exclusive install options
+`--platlib` and `--purelib` that override the wheel's
+`Root-Is-Purelib` flag and consolidate the two `*lib` scheme keys
+onto a single site directory for the install. Effect:
+
+- `--platlib`: every file the installer would route to purelib goes
+  to platlib instead, regardless of `Root-Is-Purelib` in WHEEL. This
+  covers the unprefixed wheel root and any `.data/purelib/` content.
+- `--purelib`: the symmetric inverse - everything purelib-keyed *and*
+  platlib-keyed lands in purelib.
+
+Default behaviour (neither flag set) is byte-identical to today.
+
+## Motivation
+The primary downstream consumer is RPM packaging, which sometimes
+needs to forcibly relocate an "actually purelib" wheel to platlib (or
+the reverse). Concrete drivers:
+
+- **Multilib layouts (lib vs. lib64).** On split-layout distros the
+  WHEEL spec's "Root-Is-Purelib: true" maps to `/usr/lib/...`, but a
+  package paired with arch-dependent siblings, or one packaged for
+  the platform-specific subpackage, must land under
+  `/usr/lib64/...`. The reverse can also occur (a wheel marked
+  platlib that contains no native code).
+- **Wheel author's flag is wrong or coarse.** Some build backends
+  emit `Root-Is-Purelib: true` even when the project also ships
+  arch-specific data files; downstream packagers cannot easily
+  rebuild the wheel and need a one-shot relocation switch instead.
+- **`.data/purelib/` is also affected.** A file deliberately routed
+  to `.data/purelib/` by the wheel author would otherwise still land
+  in purelib regardless of the root override; the `--platlib` flag
+  redirects that too, so all "purelib content" of the wheel is
+  consolidated in one place. Same for the inverse direction.
+
+The override is opt-in because:
+
+- the default behaviour (honour `Root-Is-Purelib`) is unchanged - it
+  is what every well-formed wheel and every other installer in the
+  ecosystem does;
+- it is intentionally a per-install decision, not configurable in
+  the wheel itself, because the same wheel may be installed into
+  different subpackages of the same RPM build with different
+  policies;
+- the WHEEL flag still wins by default - the override is a deliberate
+  packager-level choice that should be invisible in the source tree.
+
+## Specification
+
+### User-facing contract
+- Syntax: `python -m pyproject_installer install [--platlib | --purelib]
+  [other install args...]`.
+- Both flags are declared on the `install` subparser inside an
+  `argparse.add_mutually_exclusive_group()`. Passing both produces the
+  standard argparse error path (usage line on stderr, exit code 2).
+- When neither flag is set, behaviour is byte-identical to the
+  current release: `Root-Is-Purelib` from WHEEL drives the slot
+  decision and the sysconfig scheme is consumed unmodified.
+- When `--platlib` is set, the installer behaves as if every
+  purelib-keyed location were aliased to the platlib path:
+  - the wheel's unprefixed root is extracted under
+    `scheme["platlib"]`, regardless of `Root-Is-Purelib` in WHEEL;
+  - any file under `.data/purelib/` is dispatched to
+    `scheme["platlib"]`;
+  - any file under `.data/platlib/` continues to land in
+    `scheme["platlib"]` (no change);
+  - `.data/scripts/`, `.data/headers/`, `.data/data/` are unaffected.
+- `--purelib` is the symmetric inverse: every platlib-keyed location
+  is aliased to the purelib path. Same coverage of `.data/*`.
+- The override is idempotent on already-aligned wheels. Passing
+  `--platlib` to a `Root-Is-Purelib: false` wheel does not change the
+  root extraction, but it still redirects any `.data/purelib/`
+  content to platlib. No special-casing for "no-op" inputs.
+- The override applies before destdir prepending. The `--destdir`
+  contract is unchanged: the (possibly redirected) installation root
+  is prepended with destdir as today.
+- Programmatic API: `install_wheel(..., force_site=None)` accepts
+  `Literal["purelib", "platlib"] | None`.
+
+## Example
+
+```
+# Force a pure-Python wheel into platlib, e.g. because the RPM
+# subpackage owning these files lives under /usr/lib64.
+python -m pyproject_installer install \
+    --destdir /tmp/buildroot \
+    --platlib
+
+# Symmetric: force a wheel marked Root-Is-Purelib: false into purelib.
+python -m pyproject_installer install \
+    --destdir /tmp/buildroot \
+    --purelib
+
+# Combined with --rpm-filelist: the emitted filelist reflects the
+# consolidated slot. No code change in _rpm_filelist.py is needed -
+# anchor classification + set-backed output deduplicates naturally.
+python -m pyproject_installer install \
+    --destdir /tmp/buildroot \
+    --platlib \
+    --rpm-filelist dist/foo.files
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@ disable = [
     "too-many-lines",
     "too-many-locals",
     "too-many-nested-blocks",
+    "too-many-positional-arguments",
     "too-many-public-methods",
     "too-many-return-statements",
     "too-many-statements",

--- a/src/pyproject_installer/__main__.py
+++ b/src/pyproject_installer/__main__.py
@@ -59,6 +59,7 @@ def install(args, parser):
         installer=args.installer,
         strip_dist_info=args.strip_dist_info,
         rpm_filelist=args.rpm_filelist,
+        force_site=args.force_site,
     )
 
 
@@ -548,6 +549,29 @@ def main_parser(prog):
             "write an RPM %%files-compatible filelist of installed "
             "files (plus computed .pyc paths) to PATH "
             "(default: None, filelist is not written)"
+        ),
+    )
+    site_group = parser_install.add_mutually_exclusive_group()
+    site_group.add_argument(
+        "--platlib",
+        dest="force_site",
+        action="store_const",
+        const="platlib",
+        help=(
+            "force install into platlib site-packages, overriding "
+            "wheel's Root-Is-Purelib (also redirects .data/purelib "
+            "content). Mutually exclusive with --purelib."
+        ),
+    )
+    site_group.add_argument(
+        "--purelib",
+        dest="force_site",
+        action="store_const",
+        const="purelib",
+        help=(
+            "force install into purelib site-packages, overriding "
+            "wheel's Root-Is-Purelib (also redirects .data/platlib "
+            "content). Mutually exclusive with --platlib."
         ),
     )
     parser_install.set_defaults(main=install)

--- a/src/pyproject_installer/install_cmd/_install.py
+++ b/src/pyproject_installer/install_cmd/_install.py
@@ -162,9 +162,16 @@ def install_wheel(
     installer=None,
     strip_dist_info=True,
     rpm_filelist=None,
+    force_site=None,
 ):
     wheel_path = validate_wheel_path(wheel_path)
     destdir = validate_destdir(destdir)
+
+    if force_site is not None and force_site not in ("purelib", "platlib"):
+        raise ValueError(
+            "force_site must be 'purelib' or 'platlib', "
+            f"got: {force_site!r}",
+        )
 
     logger.info("Installing wheel")
     logger.info("Wheel directory: %s", wheel_path.parent)
@@ -176,6 +183,8 @@ def install_wheel(
         dist_version = whl.dist_version
         data_name = whl.data_name
         scheme = get_installation_scheme(dist_name)
+        if force_site is not None:
+            scheme["purelib"] = scheme["platlib"] = scheme[force_site]
         extraction_root = whl.extraction_root(scheme)
         rootdir = destdir / extraction_root.relative_to(extraction_root.root)
         logger.info("Wheel installation root: %s", rootdir)

--- a/tests/unit/test_install/test_installer.py
+++ b/tests/unit/test_install/test_installer.py
@@ -1039,3 +1039,246 @@ def test_rpm_filelist_sys_pycache_prefix(
             rpm_filelist=filelist,
         )
     assert not filelist.exists()
+
+
+@pytest.mark.parametrize(
+    "wheel_purelib",
+    (True, False),
+    ids=("purelib", "platlib"),
+)
+@pytest.mark.parametrize(
+    "force_site",
+    ("purelib", "platlib"),
+    ids=("force_purelib", "force_platlib"),
+)
+def test_extraction_root_force_site(
+    wheel_purelib,
+    force_site,
+    wheel_contents,
+    wheel,
+    tmpdir,
+):
+    """
+    Check force_site overrides Root-Is-Purelib for root extraction.
+    """
+    contents = wheel_contents(purelib=wheel_purelib)
+    destdir = tmpdir / "destdir"
+    destdir.mkdir()
+
+    install_wheel(
+        wheel(contents=contents),
+        destdir=destdir,
+        force_site=force_site,
+    )
+
+    scheme = get_installation_scheme("foo")
+    chosen_sitedir = Path(str(destdir) + scheme[force_site])
+    other_site = "platlib" if force_site == "purelib" else "purelib"
+    other_sitedir = Path(str(destdir) + scheme[other_site])
+
+    # /usr/lib and /usr/lib64 may collapse to the same path on
+    # non-multilib distros; only assert the negative when the two
+    # paths actually differ.
+    assert (chosen_sitedir / "foo" / "__init__.py").exists()
+    if chosen_sitedir != other_sitedir:
+        assert not (other_sitedir / "foo" / "__init__.py").exists()
+
+
+@pytest.mark.parametrize(
+    "force_site,other_site",
+    (
+        ("platlib", "purelib"),
+        ("purelib", "platlib"),
+    ),
+    ids=("force_platlib", "force_purelib"),
+)
+def test_force_site_redirects_data_subdir(
+    force_site,
+    other_site,
+    wheel_contents,
+    wheel,
+    tmpdir,
+):
+    """
+    Check .data/<other-site> content follows force_site to chosen site.
+    """
+    contents = wheel_contents()
+    contents[f"foo-1.0.data/{other_site}/extra.txt"] = "content\n"
+    destdir = tmpdir / "destdir"
+    destdir.mkdir()
+
+    install_wheel(
+        wheel(contents=contents),
+        destdir=destdir,
+        force_site=force_site,
+    )
+
+    scheme = get_installation_scheme("foo")
+    chosen_sitedir = Path(str(destdir) + scheme[force_site])
+    other_sitedir = Path(str(destdir) + scheme[other_site])
+
+    assert (chosen_sitedir / "extra.txt").exists()
+    if chosen_sitedir != other_sitedir:
+        assert not (other_sitedir / "extra.txt").exists()
+
+
+@pytest.mark.parametrize(
+    "force_site,wheel_purelib,other_site",
+    (
+        ("platlib", False, "purelib"),
+        ("purelib", True, "platlib"),
+    ),
+    ids=("force_platlib", "force_purelib"),
+)
+def test_force_site_idempotent_root_redirects_data(
+    force_site,
+    wheel_purelib,
+    other_site,
+    wheel_contents,
+    wheel,
+    tmpdir,
+):
+    """
+    Check force_site already aligned with Root-Is-Purelib keeps the
+    root unchanged but still redirects .data/<other-site> content to
+    the chosen site.
+    """
+    contents = wheel_contents(purelib=wheel_purelib)
+    contents[f"foo-1.0.data/{other_site}/extra.txt"] = "content\n"
+    destdir = tmpdir / "destdir"
+    destdir.mkdir()
+
+    install_wheel(
+        wheel(contents=contents),
+        destdir=destdir,
+        force_site=force_site,
+    )
+
+    scheme = get_installation_scheme("foo")
+    chosen_sitedir = Path(str(destdir) + scheme[force_site])
+    other_sitedir = Path(str(destdir) + scheme[other_site])
+
+    # root stayed in chosen site (no change vs default)
+    assert (chosen_sitedir / "foo" / "__init__.py").exists()
+    if chosen_sitedir != other_sitedir:
+        assert not (other_sitedir / "foo" / "__init__.py").exists()
+    # .data/<other-site> content followed the override
+    assert (chosen_sitedir / "extra.txt").exists()
+    if chosen_sitedir != other_sitedir:
+        assert not (other_sitedir / "extra.txt").exists()
+
+
+@pytest.mark.parametrize(
+    "force_site",
+    ("platlib", "purelib"),
+)
+def test_force_site_both_data_subdirs_consolidated(
+    force_site,
+    wheel_contents,
+    wheel,
+    tmpdir,
+):
+    """
+    Check force_site consolidates both .data/purelib and .data/platlib
+    content into the chosen site.
+    """
+    contents = wheel_contents()
+    contents["foo-1.0.data/purelib/from_purelib.txt"] = "p\n"
+    contents["foo-1.0.data/platlib/from_platlib.txt"] = "P\n"
+    destdir = tmpdir / "destdir"
+    destdir.mkdir()
+
+    install_wheel(
+        wheel(contents=contents),
+        destdir=destdir,
+        force_site=force_site,
+    )
+
+    chosen_sitedir = Path(
+        str(destdir) + get_installation_scheme("foo")[force_site],
+    )
+    assert (chosen_sitedir / "from_purelib.txt").exists()
+    assert (chosen_sitedir / "from_platlib.txt").exists()
+
+
+@pytest.mark.parametrize(
+    "force_site",
+    ("platlib", "purelib"),
+    ids=("force_platlib", "force_purelib"),
+)
+@pytest.mark.parametrize(
+    "wheel_purelib",
+    (True, False),
+    ids=("wheel_purelib", "wheel_platlib"),
+)
+@pytest.mark.parametrize(
+    "data_purelib",
+    ("purelib", "platlib"),
+    ids=("data_purelib", "data_platlib"),
+)
+def test_rpm_filelist_under_force_site(
+    force_site,
+    wheel_purelib,
+    data_purelib,
+    wheel_contents,
+    wheel,
+    tmpdir,
+):
+    """
+    Check rpm filelist under force_site.
+    """
+    contents = wheel_contents(purelib=wheel_purelib)
+    contents[f"foo-1.0.data/{data_purelib}/extra.txt"] = "content\n"
+    destdir = tmpdir / "destdir"
+    destdir.mkdir()
+    filelist = tmpdir / "foo.files"
+
+    install_wheel(
+        wheel(contents=contents),
+        destdir=destdir,
+        rpm_filelist=filelist,
+        force_site=force_site,
+    )
+
+    chosen_sitedir = get_installation_scheme("foo")[force_site]
+    recorded_files = filelist.read_text(encoding="utf-8").splitlines()
+    expected_files = sorted(
+        (
+            f"%dir {chosen_sitedir}/foo",
+            f"{chosen_sitedir}/foo/__init__.py",
+            f"%dir {chosen_sitedir}/foo/__pycache__",
+            *expected_pyc_lines(f"{chosen_sitedir}/foo/__init__.py"),
+            f"%dir {chosen_sitedir}/foo-1.0.dist-info",
+            f"{chosen_sitedir}/foo-1.0.dist-info/METADATA",
+            f"{chosen_sitedir}/extra.txt",
+        ),
+    )
+    assert recorded_files == expected_files
+
+
+@pytest.mark.parametrize(
+    "bad_value",
+    ("scripts", "data", "headers", "bogus", ""),
+)
+def test_force_site_invalid_value_rejected(
+    bad_value,
+    wheel_contents,
+    wheel,
+    tmpdir,
+):
+    """
+    Check install_wheel rejects force_site values outside purelib/platlib.
+    """
+    contents = wheel_contents()
+    destdir = tmpdir / "destdir"
+    destdir.mkdir()
+
+    with pytest.raises(
+        ValueError,
+        match=r"force_site must be 'purelib' or 'platlib'",
+    ):
+        install_wheel(
+            wheel(contents=contents),
+            destdir=destdir,
+            force_site=bad_value,
+        )

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -341,6 +341,7 @@ def test_install_cli_default(mock_install_wheel, mock_read_tracker):
         "installer": None,
         "strip_dist_info": True,
         "rpm_filelist": None,
+        "force_site": None,
     }
 
     project_main.main(install_args)
@@ -361,6 +362,7 @@ def test_install_cli_destdir(mock_install_wheel, mock_read_tracker):
         "installer": None,
         "strip_dist_info": True,
         "rpm_filelist": None,
+        "force_site": None,
     }
 
     project_main.main(install_args)
@@ -380,6 +382,7 @@ def test_install_cli_wheel(mock_install_wheel, mock_read_tracker):
         "installer": None,
         "strip_dist_info": True,
         "rpm_filelist": None,
+        "force_site": None,
     }
 
     project_main.main(install_args)
@@ -399,6 +402,7 @@ def test_install_cli_wheel_destdir(mock_install_wheel, mock_read_tracker):
         "installer": None,
         "strip_dist_info": True,
         "rpm_filelist": None,
+        "force_site": None,
     }
 
     project_main.main(install_args)
@@ -419,6 +423,7 @@ def test_install_cli_installer_tool(mock_install_wheel, mock_read_tracker):
         "installer": installer_tool,
         "strip_dist_info": True,
         "rpm_filelist": None,
+        "force_site": None,
     }
 
     project_main.main(install_args)
@@ -439,6 +444,7 @@ def test_install_cli_no_strip_dist_info(mock_install_wheel):
         "installer": None,
         "strip_dist_info": False,
         "rpm_filelist": None,
+        "force_site": None,
     }
 
     project_main.main(install_args)
@@ -475,10 +481,74 @@ def test_install_cli_rpm_filelist(mock_install_wheel, tmpdir):
         "installer": None,
         "strip_dist_info": True,
         "rpm_filelist": filelist,
+        "force_site": None,
     }
 
     project_main.main(install_args)
     mock_install_wheel.assert_called_once_with(*i_args, **i_kwargs)
+
+
+@pytest.mark.usefixtures("mock_read_tracker")
+def test_install_cli_platlib(mock_install_wheel):
+    """
+    Run install with --platlib.
+    """
+    install_args = ["install", "--platlib"]
+
+    destdir = Path("/")
+    wheel = Path.cwd() / "dist" / "foo.whl"
+    i_args = (wheel,)
+    i_kwargs = {
+        "destdir": destdir,
+        "installer": None,
+        "strip_dist_info": True,
+        "rpm_filelist": None,
+        "force_site": "platlib",
+    }
+
+    project_main.main(install_args)
+    mock_install_wheel.assert_called_once_with(*i_args, **i_kwargs)
+
+
+@pytest.mark.usefixtures("mock_read_tracker")
+def test_install_cli_purelib(mock_install_wheel):
+    """
+    Run install with --purelib.
+    """
+    install_args = ["install", "--purelib"]
+
+    destdir = Path("/")
+    wheel = Path.cwd() / "dist" / "foo.whl"
+    i_args = (wheel,)
+    i_kwargs = {
+        "destdir": destdir,
+        "installer": None,
+        "strip_dist_info": True,
+        "rpm_filelist": None,
+        "force_site": "purelib",
+    }
+
+    project_main.main(install_args)
+    mock_install_wheel.assert_called_once_with(*i_args, **i_kwargs)
+
+
+def test_install_cli_platlib_purelib_mutually_exclusive(
+    mock_install_wheel,
+    capsys,
+):
+    """
+    Check --platlib and --purelib together is an argparse error.
+    """
+    install_args = ["install", "--platlib", "--purelib"]
+
+    with pytest.raises(SystemExit) as exc:
+        project_main.main(install_args)
+    assert exc.value.code == ExitCodes.WRONG_USAGE
+    captured = capsys.readouterr()
+    assert not captured.out
+    # actual error message is controlled by cpython,
+    # so it's unreliable to check captured.err
+    mock_install_wheel.assert_not_called()
 
 
 def test_run_cli_default(mock_run_command, mock_read_tracker, caplog):


### PR DESCRIPTION
Mutually-exclusive `install --platlib` / `--purelib` flags that override the wheel's `Root-Is-Purelib` and consolidate the purelib/platlib scheme keys onto the chosen site for the install. Both the unprefixed wheel root and any `.data/{purelib,platlib}/` content land in the chosen slot. Default behaviour (neither flag set) is byte-identical.

See for details:
docs/designs/platlib_purelib_options.md

Fixes: https://github.com/stanislavlevin/pyproject_installer/issues/147

## Summary by Sourcery

Add CLI options to force wheel installation into either the purelib or platlib site-packages directory, overriding the wheel’s Root-Is-Purelib flag and consolidating lib-targeted content accordingly.

New Features:
- Introduce mutually exclusive --platlib and --purelib install flags to control the target site-packages directory independent of Root-Is-Purelib.
- Expose a force_site parameter in the programmatic install_wheel API and underlying WheelFile logic to select purelib or platlib explicitly.

Enhancements:
- Ensure .data/purelib and .data/platlib payloads are redirected to the chosen site when a forced target is set, including RPM filelist generation alignment.
- Document the platlib/purelib override behaviour and options in both the README and a dedicated design document.

Tests:
- Add unit tests covering force_site behaviour for root extraction, .data directory redirection, consolidation semantics, RPM filelist output, CLI flag wiring, and invalid force_site values.