### PR TITLE
maint(types): annotate codebase and enable mypy strict

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -6,7 +6,7 @@ Builds/installs PEP 517/518 projects in network-isolated envs (RPM packaging). R
 - Run everything in `.venv` (`python -m venv .venv && .venv/bin/pip install --upgrade pip`) **except self-run** — nested venvs are unsupported there.
 - Deps: `.venv/bin/pip install --group {lint,coverage,test}`; then `.venv/bin/pip install .` (required before unit/integration).
 - Validate manifest (CI gate): `.venv/bin/python -m validate_pyproject -vv pyproject.toml`.
-- Lint (run before tests): `ruff check .`; `pylint --rcfile=pyproject.toml .`; `black --check --diff .` (line-length 80).
+- Lint (run before tests): `ruff check .`; `pylint --rcfile=pyproject.toml .`; `black --check --diff .` (line-length 80); `mypy` (strict, gated in CI).
 - Unit + coverage: `COVERAGE_PROCESS_START="$(pwd)/pyproject.toml" pytest -vra --cov --cov-config=pyproject.toml tests/unit` (env var required for subprocess coverage).
 - Self-run tests (system interpreter, NOT inside `.venv`): `pip install --group test && pip install . && python3 -m pyproject_installer -v build && python3 -m pyproject_installer -v run -- pytest -vra tests/unit`.
 - Integration: `pytest -vra tests/integration`.

--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -57,6 +57,14 @@ jobs:
     - name: Black
       run: |
         .venv/bin/python -m black -v --check --diff .
+    - name: Run mypy
+      run: |
+        .venv/bin/python -m mypy \
+          --pretty \
+          --show-error-end \
+          --show-error-code-links \
+          --error-summary \
+          --color-output
 
   unit_tests:
     name: Run unit tests

--- a/backend/common.py
+++ b/backend/common.py
@@ -3,15 +3,15 @@ import re
 import time
 
 
-def normalize_name_pep427(name):
+def normalize_name_pep427(name: str) -> str:
     return re.sub(r"[-_.]+", "_", name).lower()
 
 
-def source_date_time(mtime):
+def source_date_time(mtime: float) -> int:
     """Honor reproducible builds"""
     return int(os.environ.get("SOURCE_DATE_EPOCH", mtime))
 
 
-def source_date_time_zinfo(mtime):
+def source_date_time_zinfo(mtime: float) -> tuple[int, int, int, int, int, int]:
     """Honor reproducible builds"""
     return time.gmtime(source_date_time(mtime))[0:6]

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,13 +1,22 @@
+import sys
 from pathlib import Path
+from typing import TypedDict
 
-try:
-    # Python 3.11+
+if sys.version_info >= (3, 11):
     import tomllib
-except ModuleNotFoundError:
+else:
     from ._vendor import tomli as tomllib
 
 
-def validate_path(cwd, path):
+class BackendConfigType(TypedDict, total=False):
+    package_dir: str
+    version_file: str | None
+    include_dirs_sdist: list[str] | None
+    include_files_sdist: list[str] | None
+    license_files: list[str]
+
+
+def validate_path(cwd: Path, path: Path) -> Path:
     err_msg = f"{path} should be relative"
     if path.is_absolute():
         raise ValueError(err_msg)
@@ -20,9 +29,9 @@ def validate_path(cwd, path):
     return abs_path
 
 
-def parse_backend_config(cwd, path):
+def parse_backend_config(cwd: Path, path: Path) -> BackendConfigType:
     """Parses table tool.pyproject_installer.backend of pyproject.toml"""
-    backend_config = {}
+    backend_config: BackendConfigType = {}
     with path.open("rb") as f:
         pyproject_data = tomllib.load(f)
 

--- a/backend/metadata.py
+++ b/backend/metadata.py
@@ -1,23 +1,89 @@
 import ast
+import sys
 from abc import ABC, abstractmethod
+from collections.abc import Mapping
 from contextlib import suppress
 from email.generator import BytesGenerator
 from email.headerregistry import Address
 from email.message import Message
 from io import BytesIO
 from pathlib import Path
+from typing import Any, Literal, TypedDict, get_args
 
-try:
-    # Python 3.11+
+if sys.version_info >= (3, 11):
     import tomllib
-except ModuleNotFoundError:
+else:
     from ._vendor import tomli as tomllib
+from .config import BackendConfigType
+
+WheelMetadataType = TypedDict(
+    "WheelMetadataType",
+    {
+        "Wheel-Version": str,
+        "Generator": str,
+        "Root-Is-Purelib": str,
+        "Tag": str,
+    },
+)
 
 
-def parse_version_from_file(version_file):
+WheelMetadataArgType = TypedDict(
+    "WheelMetadataArgType",
+    {
+        "wheel-version": str,
+        "generator": str,
+        "root-is-purelib": str,
+        "tags": list[str],
+    },
+)
+
+
+Pep621MetadataType = TypedDict(
+    "Pep621MetadataType",
+    {
+        "name": str,
+        "version": str,
+        "description": str,
+        "readme": dict[str, str] | str,
+        "requires-python": str,
+        "license": dict[str, str],
+        "authors": list[dict[str, str]],
+        "maintainers": list[dict[str, str]],
+        "keywords": list[str],
+        "classifiers": list[str],
+        "dynamic": list[str],
+        "urls": dict[str, str],
+    },
+    total=False,
+)
+
+
+Pep621SupportedFieldsType = Literal[
+    "name",
+    "version",
+    "description",
+    "readme",
+    "requires-python",
+    "license",
+    "authors",
+    "maintainers",
+    "keywords",
+    "classifiers",
+    "dynamic",
+    "urls",
+]
+
+
+PEP621_SUPPORTED_FIELDS: set[Pep621SupportedFieldsType] = set(
+    get_args(Pep621SupportedFieldsType),
+)
+
+
+def parse_version_from_file(version_file: str | Path) -> str:
     """
     Parse version from given file,
     expected format: version = "version_value"
+    or annotated:    version: str = "version_value"
     """
     err_msg = f"missing version in: {version_file}"
 
@@ -37,41 +103,41 @@ def parse_version_from_file(version_file):
     ):
         return child.value.value
 
+    if (
+        isinstance(child, ast.AnnAssign)
+        and child.simple == 1
+        and isinstance(child.target, ast.Name)
+        and child.target.id == "version"
+        and isinstance(child.value, ast.Constant)
+        and isinstance(child.value.value, str)
+    ):
+        return child.value.value
+
     raise ValueError(err_msg)
 
 
-def parse_pep621_metadata(path, backend_config):
+def parse_pep621_metadata(
+    path: Path,
+    backend_config: BackendConfigType,
+) -> Pep621MetadataType:
     """
     Parses pyproject.toml with predefined set of fields names.
 
     Actual pre-validation of config is made by validate-pyproject.
     """
-    metadata = {}
+    metadata: Pep621MetadataType = {}
     with path.open("rb") as f:
         pyproject_data = tomllib.load(f)
 
     project = pyproject_data["project"]
 
-    supported_fields = {
-        "name",
-        "version",
-        "description",
-        "readme",
-        "requires-python",
-        "license",
-        "authors",
-        "keywords",
-        "classifiers",
-        "dynamic",
-        "urls",
-    }
-    extra_fields = project.keys() - set(supported_fields)
+    extra_fields = project.keys() - set(PEP621_SUPPORTED_FIELDS)
     if extra_fields:
         raise ValueError(
             f"Unexpected fields in project table: {', '.join(extra_fields)}",
         )
 
-    for attr in supported_fields:
+    for attr in PEP621_SUPPORTED_FIELDS:
         with suppress(KeyError):
             metadata[attr] = project[attr]
 
@@ -92,19 +158,23 @@ def parse_pep621_metadata(path, backend_config):
         if "version" not in dynamic:
             raise KeyError("Missing version of project")
 
-        metadata["version"] = parse_version_from_file(
-            backend_config["version_file"],
-        )
+        if (version_file := backend_config["version_file"]) is None:
+            raise ValueError(
+                "'version_file' (backend config option) is required "
+                "for dynamic version",
+            )
+
+        metadata["version"] = parse_version_from_file(version_file)
 
     return metadata
 
 
 class Metadata(ABC):
     @abstractmethod
-    def __init__(self, metadata):
+    def __init__(self, metadata: Mapping[str, Any]) -> None:
         self._metadata = Message()
 
-    def dump_as_bytes(self):
+    def dump_as_bytes(self) -> bytes:
         fp = BytesIO()
         g = BytesGenerator(fp, maxheaderlen=0)
         g.flatten(self._metadata)
@@ -116,11 +186,11 @@ class CoreMetadata(Metadata):
     Convert PEP621 metadata to core metadata without content validation
     """
 
-    def __init__(self, metadata):
+    def __init__(self, metadata: Pep621MetadataType) -> None:
         super().__init__(metadata)
 
         # files required for build sdist/wheel
-        self.required_files = set()
+        self.required_files: set[str] = set()
 
         # required fields: Metadata-Version, Name and Version
         self._metadata["Metadata-Version"] = "2.1"
@@ -247,7 +317,12 @@ class CoreMetadata(Metadata):
                     f"readme should be string or dictionary, given: {readme!r}",
                 )
 
-    def _parse_authors(self, authors):
+    def _parse_authors(
+        self,
+        authors: list[dict[str, str]],
+    ) -> tuple[list[str], list[str]]:
+        msg_authors: list[str] = []
+        msg_emails: list[str] = []
         for author in authors:
             unknown_keys = author.keys() - {"name", "email"}
             if unknown_keys:
@@ -271,7 +346,7 @@ class CoreMetadata(Metadata):
 
 
 class WheelMetadata(Metadata):
-    def __init__(self, metadata):
+    def __init__(self, metadata: WheelMetadataArgType) -> None:
         super().__init__(metadata)
         self._metadata["Wheel-Version"] = metadata["wheel-version"]
         self._metadata["Generator"] = metadata["generator"]

--- a/backend/sdist.py
+++ b/backend/sdist.py
@@ -16,8 +16,11 @@ import logging
 import os
 import tarfile
 import time
+from collections.abc import Iterable
 from io import BytesIO
 from pathlib import Path
+from types import TracebackType
+from typing import IO, Any
 
 from .common import normalize_name_pep427, source_date_time
 from .config import parse_backend_config
@@ -31,7 +34,13 @@ logger = logging.getLogger(__name__)
 
 
 class SdistBuilder:
-    def __init__(self, cwd, distr_name, distr_version, sdist_directory):
+    def __init__(
+        self,
+        cwd: Path,
+        distr_name: str,
+        distr_version: str,
+        sdist_directory: Path,
+    ) -> None:
         self.cwd = cwd
         self.distr_name = distr_name
         self.distr_version = distr_version
@@ -44,19 +53,24 @@ class SdistBuilder:
             format=tarfile.PAX_FORMAT,
         )
 
-    def __enter__(self):
+    def __enter__(self) -> "SdistBuilder":
         return self
 
-    def __exit__(self, exc_type, exc_value, traceback):
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
         self.close()
 
-    def close(self):
+    def close(self) -> None:
         self._tarfile.close()
 
-    def __del__(self):
+    def __del__(self) -> None:
         self.close()
 
-    def package_modules(self, package_dir):
+    def package_modules(self, package_dir: Path) -> None:
         """Package Python packages and modules"""
         for root, dirs, files in os.walk(package_dir):
             dirs[:] = [d for d in sorted(dirs) if d != "__pycache__"]
@@ -67,8 +81,8 @@ class SdistBuilder:
                 if fp.suffix == ".pyc":
                     continue
 
-                # allow only Python modules for now
-                if fp.suffix != ".py":
+                # allow Python modules and the PEP 561 typing marker
+                if fp.suffix != ".py" and fp.name != "py.typed":
                     continue
 
                 fp_rel = fp.relative_to(self.cwd)
@@ -91,7 +105,7 @@ class SdistBuilder:
                         date_time=source_date_time(stat.st_mtime),
                     )
 
-    def package_metadata(self, core_metadata):
+    def package_metadata(self, core_metadata: bytes) -> None:
         with BytesIO(core_metadata) as src:
             self.package_file(
                 src,
@@ -100,7 +114,7 @@ class SdistBuilder:
                 date_time=source_date_time(time.time()),
             )
 
-    def package_files(self, files):
+    def package_files(self, files: Iterable[str]) -> None:
         for file in files:
             if Path(file).is_absolute():
                 raise ValueError(f"Path should be relative, given: {file}")
@@ -118,13 +132,19 @@ class SdistBuilder:
                         date_time=source_date_time(stat.st_mtime),
                     )
 
-    def package_license_files(self, patterns):
+    def package_license_files(self, patterns: Iterable[str]) -> None:
         # supported license files from root directory only
         self.package_files(
             (f.name for ptrn in patterns for f in self.cwd.glob(ptrn)),
         )
 
-    def package_file(self, src, filename, size, date_time):
+    def package_file(
+        self,
+        src: IO[bytes],
+        filename: str,
+        size: int,
+        date_time: int,
+    ) -> None:
         tarinfo = tarfile.TarInfo(str(self.root_dir / filename))
         tarinfo.size = size
         tarinfo.mtime = date_time
@@ -132,7 +152,10 @@ class SdistBuilder:
         self._tarfile.addfile(tarinfo, fileobj=src)
 
 
-def build_sdist(sdist_directory, config_settings=None):
+def build_sdist(
+    sdist_directory: str | Path,
+    config_settings: dict[str, Any] | None = None,
+) -> str:
     cwd = Path.cwd()
     pyproject = cwd / "pyproject.toml"
 

--- a/backend/wheel.py
+++ b/backend/wheel.py
@@ -17,8 +17,11 @@ import logging
 import os
 import time
 from base64 import urlsafe_b64encode
+from collections.abc import Iterable
 from io import BytesIO, TextIOWrapper
 from pathlib import Path
+from types import TracebackType
+from typing import IO, Any
 from zipfile import ZIP_DEFLATED, ZipFile, ZipInfo
 
 from .common import normalize_name_pep427, source_date_time_zinfo
@@ -33,29 +36,40 @@ logger = logging.getLogger(__name__)
 
 
 class WheelBuilder:
-    def __init__(self, distr_name, distr_version, wheel_directory):
+
+    def __init__(
+        self,
+        distr_name: str,
+        distr_version: str,
+        wheel_directory: Path,
+    ) -> None:
         self.distr_name = distr_name
         self.distr_version = distr_version
         self.filename = f"{distr_name}-{distr_version}-py3-none-any.whl"
         self.wheel_path = wheel_directory / self.filename
         self._zipfile = ZipFile(self.wheel_path, "w")
         self.dist_info = f"{distr_name}-{distr_version}.dist-info"
-        self.records = []
+        self.records: list[tuple[str, str, int | str]] = []
         self.digest_alg = "sha256"
 
-    def __enter__(self):
+    def __enter__(self) -> "WheelBuilder":
         return self
 
-    def __exit__(self, exc_type, exc_value, traceback):
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
         self.close()
 
-    def close(self):
+    def close(self) -> None:
         self._zipfile.close()
 
-    def __del__(self):
+    def __del__(self) -> None:
         self.close()
 
-    def add_record(self, filename, digest, size):
+    def add_record(self, filename: str, digest: bytes, size: int) -> None:
         self.records.append(
             (
                 filename,
@@ -67,7 +81,7 @@ class WheelBuilder:
             ),
         )
 
-    def package_modules(self, package_dir):
+    def package_modules(self, package_dir: Path) -> None:
         """Package Python packages and modules"""
         for root, dirs, files in os.walk(package_dir):
             dirs[:] = [d for d in sorted(dirs) if d != "__pycache__"]
@@ -77,8 +91,8 @@ class WheelBuilder:
                 if fp.suffix == ".pyc":
                     continue
 
-                # allow only Python modules for now
-                if fp.suffix != ".py":
+                # allow Python modules and the PEP 561 typing marker
+                if fp.suffix != ".py" and fp.name != "py.typed":
                     continue
 
                 fp_rel = fp.relative_to(package_dir)
@@ -100,7 +114,7 @@ class WheelBuilder:
                         source_date_time_zinfo(stat.st_mtime),
                     )
 
-    def package_wheel_metadata(self):
+    def package_wheel_metadata(self) -> None:
         dist_info_wheel = Path(self.dist_info) / "WHEEL"
         wheel_data = WheelMetadata(
             {
@@ -119,7 +133,7 @@ class WheelBuilder:
                 source_date_time_zinfo(time.time()),
             )
 
-    def package_metadata(self, core_metadata):
+    def package_metadata(self, core_metadata: bytes) -> None:
         dist_info_metadata = Path(self.dist_info) / "METADATA"
 
         with BytesIO(core_metadata) as src:
@@ -129,7 +143,11 @@ class WheelBuilder:
                 source_date_time_zinfo(time.time()),
             )
 
-    def package_license_files(self, cwd, patterns):
+    def package_license_files(
+        self,
+        cwd: Path,
+        patterns: Iterable[str],
+    ) -> None:
         # supported license files from root directory only
         for pattern in patterns:
             for file in cwd.glob(pattern):
@@ -143,7 +161,12 @@ class WheelBuilder:
                             source_date_time_zinfo(stat.st_mtime),
                         )
 
-    def package_file(self, src, filename, date_time):
+    def package_file(
+        self,
+        src: IO[bytes],
+        filename: str,
+        date_time: tuple[int, int, int, int, int, int],
+    ) -> None:
         zinfo = ZipInfo(filename, date_time=date_time)
         zinfo.external_attr = 0o644 << 16
         zinfo.compress_type = ZIP_DEFLATED
@@ -160,7 +183,7 @@ class WheelBuilder:
 
         self.add_record(filename, h.digest(), zinfo.file_size)
 
-    def package_record(self):
+    def package_record(self) -> None:
         dist_info_record = Path(self.dist_info) / "RECORD"
         zinfo = ZipInfo(
             str(dist_info_record),
@@ -178,7 +201,11 @@ class WheelBuilder:
             writer.writerows(self.records)
 
 
-def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
+def build_wheel(
+    wheel_directory: str | Path,
+    config_settings: dict[str, Any] | None = None,
+    metadata_directory: str | Path | None = None,
+) -> str:
     cwd = Path.cwd()
     pyproject = cwd / "pyproject.toml"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,7 @@ omit = [
 [tool.coverage.report]
 skip_covered = false
 show_missing = true
+fail_under = 100
 
 [tool.coverage.paths]
 source = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Libraries",
+    "Typing :: Typed",
 ]
 dynamic = ["version"]
 
@@ -45,6 +46,7 @@ coverage = [
 ]
 lint = [
     "black",
+    "mypy",
     "pylint",
     "ruff",
     {include-group = "test"},
@@ -197,3 +199,31 @@ ignore = [
 [tool.ruff.lint.flake8-pytest-style]
 parametrize-values-type = "tuple"
 parametrize-names-type = "csv"
+
+[tool.mypy]
+strict = true
+python_version = "3.10"
+files = ["src", "backend", "tests"]
+exclude = ['_vendor/', '\.venv', '\.run_venv', 'build/', '\.tox/']
+
+[[tool.mypy.overrides]]
+module = "pyproject_installer._vendor.*"
+follow_imports = "silent"
+
+[[tool.mypy.overrides]]
+module = "tests.*"
+disallow_untyped_defs = false
+disallow_incomplete_defs = false
+disallow_untyped_calls = false
+
+# Tests reach into private internals of these modules (for mocker.patch
+# of imported names, direct access to module-level constants, etc.).
+# Allow implicit re-exports so tests can `from x import name`.
+[[tool.mypy.overrides]]
+module = [
+    "pyproject_installer.__main__",
+    "pyproject_installer.deps_cmd.collectors",
+    "pyproject_installer.run_cmd._run_command",
+    "pyproject_installer.run_cmd._run_env",
+]
+implicit_reexport = true

--- a/src/pyproject_installer/__main__.py
+++ b/src/pyproject_installer/__main__.py
@@ -17,7 +17,9 @@ import json
 import logging
 import os
 import sys
+from collections.abc import Callable, Sequence
 from pathlib import Path
+from typing import Any, NoReturn
 
 from . import __version__ as project_version
 from .build_cmd import WHEEL_TRACKER, build_sdist, build_wheel
@@ -30,7 +32,7 @@ from .run_cmd import run_command
 logger = logging.getLogger(Path(__file__).parent.name)
 
 
-def build(args, parser):
+def build(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
     srcdir = args.srcdir or Path.cwd()
     outdir = srcdir / "dist" if args.outdir is None else args.outdir
     try:
@@ -47,7 +49,7 @@ def build(args, parser):
     )
 
 
-def install(args, parser):
+def install(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
     try:
         wheel = default_built_wheel() if args.wheel is None else args.wheel
     except ValueError as e:
@@ -63,8 +65,13 @@ def install(args, parser):
     )
 
 
-def deps(action_name):
-    def wrapped(args, parser):
+def deps(
+    action_name: str,
+) -> Callable[[argparse.Namespace, argparse.ArgumentParser], None]:
+    def wrapped(
+        args: argparse.Namespace,
+        parser: argparse.ArgumentParser,
+    ) -> None:
         depsconfig = args.depsconfig or Path.cwd() / DEFAULT_CONFIG_NAME
 
         if (
@@ -88,22 +95,23 @@ def deps(action_name):
 
 
 class RunnerResult:
+
     def __init__(
         self,
-        status,
-        message,
-        log,
+        status: ExitCodes,
+        message: str | None,
+        log: Callable[..., None],
         *,
-        exception=None,
-        print_traceback=False,
-    ):
+        exception: BaseException | None = None,
+        print_traceback: bool = False,
+    ) -> None:
         self.status = status
         self.message = message
         self.log = log
         self.exception = exception
         self.print_traceback = print_traceback
 
-    def report(self):
+    def report(self) -> None:
         status_msg = "Command's result: %(status)s"
         if self.message is not None:
             status_msg += " (%(message)s)"
@@ -120,7 +128,7 @@ class RunnerResult:
                 self.log(f"{error_msg} %s", str(self.exception))
 
 
-def run(args, parser):
+def run(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
     try:
         wheel = default_built_wheel() if args.wheel is None else args.wheel
     except ValueError as e:
@@ -163,7 +171,7 @@ def run(args, parser):
     sys.exit(result.status)
 
 
-def default_built_wheel():
+def default_built_wheel() -> Path:
     """
     By default the `.build` module saves wheel into 'srcdir/dist' and tracks
     it in 'srcdir/dist/.wheeltracker'.
@@ -183,7 +191,7 @@ def default_built_wheel():
     return default_wheel_dir / wheel_filename
 
 
-def convert_config_settings(value):
+def convert_config_settings(value: str | None) -> dict[str, Any] | None:
     if value is None:
         return None
 
@@ -203,7 +211,7 @@ def convert_config_settings(value):
 
 
 class MainArgumentParser(argparse.ArgumentParser):
-    def error(self, message):
+    def error(self, message: str) -> NoReturn:
         """Overrides default exit code(2) with our"""
         try:
             super().error(message)
@@ -212,21 +220,35 @@ class MainArgumentParser(argparse.ArgumentParser):
             raise
 
 
-def deps_subparsers(parser):
+def deps_subparsers(parser: argparse.ArgumentParser) -> None:
     subparsers = parser.add_subparsers(
         title="deps subcommands",
         help="--help for additional help",
         required=True,
     )
 
-    def add_deps_argument(parser, destname, *args, **kwargs):
+    def add_deps_argument(
+        parser: argparse.ArgumentParser,
+        destname: str,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
         parser.add_argument(*args, **kwargs)
         destnames = parser.get_default("main_args") or []
         destnames.append(destname)
         parser.set_defaults(main_args=destnames)
 
-    def add_deps_parser(parsers, name, *args, **kwargs):
-        parser = parsers.add_parser(name, *args, **kwargs)
+    def add_deps_parser(
+        parsers: "argparse._SubParsersAction[argparse.ArgumentParser]",
+        name: str,
+        *args: Any,
+        **kwargs: Any,
+    ) -> argparse.ArgumentParser:
+        parser = parsers.add_parser(
+            name,
+            *args,
+            **kwargs,
+        )
         parser.set_defaults(main=deps(name))
         return parser
 
@@ -411,7 +433,7 @@ def deps_subparsers(parser):
     )
 
 
-def main_parser(prog):
+def main_parser(prog: str) -> MainArgumentParser:
     parser = MainArgumentParser(
         description=(
             "Build, check and install Python project from source tree in "
@@ -627,12 +649,12 @@ def main_parser(prog):
     return parser
 
 
-def emit_less_than_warning(record):
+def emit_less_than_warning(record: logging.LogRecord) -> bool:
     # nonzero if record should be logged
     return record.levelno < logging.WARNING
 
 
-def setup_logging(*, verbose=False):
+def setup_logging(*, verbose: bool = False) -> None:
     # emit WARNING, ERROR and CRITICAL to stderr
     stderr_handler = logging.StreamHandler(sys.stderr)
     stderr_handler.setLevel(logging.WARNING)
@@ -655,7 +677,10 @@ def setup_logging(*, verbose=False):
     )
 
 
-def main(cli_args, prog=f"python -m {__package__}"):
+def main(
+    cli_args: Sequence[str],
+    prog: str = f"python -m {__package__}",
+) -> None:
     parser = main_parser(prog)
     args = parser.parse_args(cli_args)
     setup_logging(verbose=args.verbose)

--- a/src/pyproject_installer/build_cmd/_build.py
+++ b/src/pyproject_installer/build_cmd/_build.py
@@ -1,9 +1,11 @@
 import logging
 import shutil
 import sys
+from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from typing import Any, Literal, get_args
 
 from ..lib.build_backend import backend_hook
 from ..lib.wheel import WheelFile
@@ -19,14 +21,25 @@ logger = logging.getLogger(__name__)
 
 WHEEL_TRACKER = ".wheeltracker"
 
-SUPPORTED_BUILD_HOOKS = (
+
+SUPPORTED_BUILD_HOOKS_TYPE = Literal[
     "build_wheel",
     "build_sdist",
     "prepare_metadata_for_build_wheel",
-)
+]
 
 
-def build(srcdir, *, outdir, hook, config=None, verbose=False):
+SUPPORTED_BUILD_HOOKS: tuple[str, ...] = get_args(SUPPORTED_BUILD_HOOKS_TYPE)
+
+
+def build(
+    srcdir: Path,
+    *,
+    outdir: Path,
+    hook: SUPPORTED_BUILD_HOOKS_TYPE,
+    config: dict[str, Any] | None = None,
+    verbose: bool = False,
+) -> str:
     logger.info("Source tree: %s", srcdir)
     logger.info("Output dir: %s", outdir)
     if config is not None:
@@ -51,12 +64,18 @@ def build(srcdir, *, outdir, hook, config=None, verbose=False):
         srcdir=srcdir,
         verbose=verbose,
         hook=hook,
-        hook_args=[(str(outdir),), {"config_settings": config}],
+        hook_args=((str(outdir),), {"config_settings": config}),
     )
     return hook_result["result"]
 
 
-def build_wheel(srcdir, *, outdir, config=None, verbose=False):
+def build_wheel(
+    srcdir: Path,
+    *,
+    outdir: Path,
+    config: dict[str, Any] | None = None,
+    verbose: bool = False,
+) -> None:
     logger.info("Building wheel")
     wheel_filename = build(
         srcdir,
@@ -71,7 +90,13 @@ def build_wheel(srcdir, *, outdir, config=None, verbose=False):
     logger.info("Built wheel: %s", wheel_filename)
 
 
-def build_sdist(srcdir, *, outdir, config=None, verbose=False):
+def build_sdist(
+    srcdir: Path,
+    *,
+    outdir: Path,
+    config: dict[str, Any] | None = None,
+    verbose: bool = False,
+) -> None:
     logger.info("Building sdist")
     sdist_filename = build(
         srcdir,
@@ -84,7 +109,13 @@ def build_sdist(srcdir, *, outdir, config=None, verbose=False):
 
 
 @contextmanager
-def build_out_tmpdir(srcdir, hook, config, verbose):
+def build_out_tmpdir(
+    srcdir: Path,
+    hook: SUPPORTED_BUILD_HOOKS_TYPE,
+    config: dict[str, Any] | None,
+    *,
+    verbose: bool,
+) -> Iterator[tuple[str, Path]]:
     tmpdir = TemporaryDirectory()
     tmp_path = Path(tmpdir.name)
     try:
@@ -100,7 +131,13 @@ def build_out_tmpdir(srcdir, hook, config, verbose):
         tmpdir.cleanup()
 
 
-def build_metadata(srcdir, *, outdir, config=None, verbose=False):
+def build_metadata(
+    srcdir: Path,
+    *,
+    outdir: Path,
+    config: dict[str, Any] | None = None,
+    verbose: bool = False,
+) -> str:
     """Build core metadata and put it on outdir"""
     logger.info("Building metadata")
     metadata_filename = "METADATA"
@@ -114,10 +151,10 @@ def build_metadata(srcdir, *, outdir, config=None, verbose=False):
         ) from None
     outdir = outdir.resolve(strict=True)
 
-    hook = "prepare_metadata_for_build_wheel"
+    hook: SUPPORTED_BUILD_HOOKS_TYPE = "prepare_metadata_for_build_wheel"
     logger.info("Building metadata with %s", hook)
     with (
-        build_out_tmpdir(srcdir, hook, config, verbose) as (
+        build_out_tmpdir(srcdir, hook, config, verbose=verbose) as (
             distinfo_dir,
             tmp_path,
         ),
@@ -136,16 +173,16 @@ def build_metadata(srcdir, *, outdir, config=None, verbose=False):
     hook = "build_wheel"
     logger.info("Fallback to building metadata with %s", hook)
     with (
-        build_out_tmpdir(srcdir, hook, config, verbose) as (
+        build_out_tmpdir(srcdir, hook, config, verbose=verbose) as (
             wheel_filename,
             tmp_path,
         ),
     ):
         wheel_path = tmp_path / wheel_filename
         with WheelFile(wheel_path) as whl:
-            metadata_path_src = whl.dist_info / metadata_filename
+            metadata_path_zip_src = whl.dist_info / metadata_filename
             with (
-                metadata_path_src.open(mode="rb") as fsrc,
+                metadata_path_zip_src.open(mode="rb") as fsrc,
                 metadata_path_dest.open(mode="wb") as fdst,
             ):
                 shutil.copyfileobj(fsrc, fdst)

--- a/src/pyproject_installer/deps_cmd/_deps_command.py
+++ b/src/pyproject_installer/deps_cmd/_deps_command.py
@@ -1,6 +1,13 @@
+from pathlib import Path
+from typing import Any
+
 from .deps_config import DepsSourcesConfig
 
 
-def deps_command(action, depsconfig, **kwargs):
+def deps_command(
+    action: str,
+    depsconfig: str | Path | None,
+    **kwargs: Any,
+) -> Any:
     config = DepsSourcesConfig(depsconfig)
     return getattr(config, action)(**kwargs)

--- a/src/pyproject_installer/deps_cmd/collectors/__init__.py
+++ b/src/pyproject_installer/deps_cmd/collectors/__init__.py
@@ -1,3 +1,4 @@
+from .collector import Collector
 from .hatch import HatchCollector
 from .metadata import MetadataCollector
 from .pdm import PdmCollector
@@ -11,24 +12,25 @@ from .tox import ToxCollector
 
 __all__ = ["SUPPORTED_COLLECTORS", "get_collector"]
 
-SUPPORTED_COLLECTORS = {
-    cls.name: cls
-    for cls in [
-        Pep517Collector,
-        Pep518Collector,
-        MetadataCollector,
-        PipReqFileCollector,
-        PoetryCollector,
-        ToxCollector,
-        HatchCollector,
-        PdmCollector,
-        PipenvCollector,
-        Pep735Collector,
-    ]
-}
+# Lifted out of the dict comprehension so mypy infers type[Collector],
+# not ABCMeta.
+_COLLECTOR_CLASSES: list[type[Collector]] = [
+    Pep517Collector,
+    Pep518Collector,
+    MetadataCollector,
+    PipReqFileCollector,
+    PoetryCollector,
+    ToxCollector,
+    HatchCollector,
+    PdmCollector,
+    PipenvCollector,
+    Pep735Collector,
+]
+
+SUPPORTED_COLLECTORS = {cls.name: cls for cls in _COLLECTOR_CLASSES}
 
 
-def get_collector(name):
+def get_collector(name: str) -> type[Collector] | None:
     try:
         return SUPPORTED_COLLECTORS[name]
     except KeyError:

--- a/src/pyproject_installer/deps_cmd/collectors/collector.py
+++ b/src/pyproject_installer/deps_cmd/collectors/collector.py
@@ -1,9 +1,11 @@
 from abc import ABC, abstractmethod
+from collections.abc import Iterator
+from typing import ClassVar
 
 
 class Collector(ABC):
-    name = None
+    name: ClassVar[str]
 
     @abstractmethod
-    def collect(self):
+    def collect(self) -> Iterator[str]:
         """Implements collecting list of dependencies from sources"""

--- a/src/pyproject_installer/deps_cmd/collectors/hatch.py
+++ b/src/pyproject_installer/deps_cmd/collectors/hatch.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterator
 from pathlib import Path
 
 from ...lib import is_pep508_requirement, tomllib
@@ -21,16 +22,16 @@ class HatchCollector(Collector):
 
     name = "hatch"
 
-    def __init__(self, hatchconfig, hatchenv):
+    def __init__(self, hatchconfig: str | Path, hatchenv: str) -> None:
         self.hatchconfig = Path(hatchconfig)
         self.hatchenv = hatchenv
 
-    def _hatchenv_data(self):
+    def collect(self) -> Iterator[str]:
         with self.hatchconfig.open("rb") as f:
             hatch_data = tomllib.load(f)
         if self.hatchconfig.name == "pyproject.toml":
             try:
-                env_data = hatch_data["tool"]["hatch"]["envs"][self.hatchenv]
+                data = hatch_data["tool"]["hatch"]["envs"][self.hatchenv]
             except KeyError:
                 raise ValueError(
                     f"Hatch: missing tool.hatch.envs.{self.hatchenv} table in "
@@ -39,16 +40,13 @@ class HatchCollector(Collector):
         else:
             # hatch.toml or custom config
             try:
-                env_data = hatch_data["envs"][self.hatchenv]
+                data = hatch_data["envs"][self.hatchenv]
             except KeyError:
                 raise ValueError(
                     f"Hatch: missing envs.{self.hatchenv} table in "
                     f"{self.hatchconfig.name}",
                 ) from None
-        return env_data
 
-    def collect(self):
-        data = self._hatchenv_data()
         try:
             deps = data["dependencies"]
         except KeyError:

--- a/src/pyproject_installer/deps_cmd/collectors/metadata.py
+++ b/src/pyproject_installer/deps_cmd/collectors/metadata.py
@@ -1,4 +1,5 @@
 import email
+from collections.abc import Iterator
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -20,10 +21,13 @@ class MetadataCollector(Collector):
 
     name = "metadata"
 
-    def collect(self):
+    def collect(self) -> Iterator[str]:
         with TemporaryDirectory() as tmpdir:
             tmp_path = Path(tmpdir)
-            metadata_filename = build_metadata(Path.cwd(), outdir=tmp_path)
+            metadata_filename = build_metadata(
+                Path.cwd(),
+                outdir=tmp_path,
+            )
             metadata_path = tmp_path / metadata_filename
             metadata_text = metadata_path.read_text(encoding="utf-8")
         metadata_email = email.message_from_string(metadata_text)

--- a/src/pyproject_installer/deps_cmd/collectors/pdm.py
+++ b/src/pyproject_installer/deps_cmd/collectors/pdm.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterator
 from pathlib import Path
 
 from ...lib import is_pep508_requirement, tomllib
@@ -16,10 +17,10 @@ class PdmCollector(Collector):
 
     name = "pdm"
 
-    def __init__(self, group):
+    def __init__(self, group: str) -> None:
         self.group = group
 
-    def collect(self):
+    def collect(self) -> Iterator[str]:
         pyproject_file = Path.cwd() / "pyproject.toml"
 
         with pyproject_file.open("rb") as f:

--- a/src/pyproject_installer/deps_cmd/collectors/pep517.py
+++ b/src/pyproject_installer/deps_cmd/collectors/pep517.py
@@ -1,4 +1,5 @@
 import sys
+from collections.abc import Iterator
 from pathlib import Path
 
 from ...lib import is_pep508_requirement
@@ -16,7 +17,7 @@ class Pep517Collector(Collector):
 
     name = "pep517"
 
-    def collect(self):
+    def collect(self) -> Iterator[str]:
         for req in backend_hook(
             python=sys.executable,
             srcdir=Path.cwd(),

--- a/src/pyproject_installer/deps_cmd/collectors/pep518.py
+++ b/src/pyproject_installer/deps_cmd/collectors/pep518.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterator
 from pathlib import Path
 
 from ...lib import is_pep508_requirement
@@ -14,7 +15,7 @@ class Pep518Collector(Collector):
 
     name = "pep518"
 
-    def collect(self):
+    def collect(self) -> Iterator[str]:
         build_system = parse_build_system_spec(Path.cwd())
 
         for req in build_system["requires"]:

--- a/src/pyproject_installer/deps_cmd/collectors/pep735.py
+++ b/src/pyproject_installer/deps_cmd/collectors/pep735.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterator
 from pathlib import Path
 
 from ...lib import dependency_groups, errors, requirements, tomllib
@@ -16,11 +17,11 @@ class Pep735Collector(Collector):
 
     name = "pep735"
 
-    def __init__(self, group):
+    def __init__(self, group: str) -> None:
         # group name can be non-normalized
         self.group = group
 
-    def collect(self):
+    def collect(self) -> Iterator[str]:
         pyproject_file = Path.cwd() / "pyproject.toml"
 
         with pyproject_file.open("rb") as f:
@@ -42,7 +43,7 @@ class Pep735Collector(Collector):
             )
 
         try:
-            return dependency_groups.resolve_dependency_groups(
+            yield from dependency_groups.resolve_dependency_groups(
                 groups_data,
                 self.group,
             )

--- a/src/pyproject_installer/deps_cmd/collectors/pip_reqfile.py
+++ b/src/pyproject_installer/deps_cmd/collectors/pip_reqfile.py
@@ -1,4 +1,5 @@
 import re
+from collections.abc import Iterator
 from pathlib import Path
 
 from ...lib import is_pep508_requirement
@@ -18,14 +19,14 @@ class PipReqFileCollector(Collector):
 
     name = "pip_reqfile"
 
-    def __init__(self, reqfile):
+    def __init__(self, reqfile: str | Path) -> None:
         self.reqfile = Path(reqfile)
 
-    def collect(self):
+    def collect(self) -> Iterator[str]:
         # see pip._internal.req.req_file.ignore_comments
         comment_re = re.compile(r"(^|\s+)#.*$")
 
-        def _parse_pip_reqline(line):
+        def _parse_pip_reqline(line: str) -> str:
             return comment_re.sub("", line).strip()
 
         with self.reqfile.open(encoding="utf-8") as f:

--- a/src/pyproject_installer/deps_cmd/collectors/pipenv.py
+++ b/src/pyproject_installer/deps_cmd/collectors/pipenv.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterator
 from pathlib import Path
 
 from ...lib import is_pep508_requirement, markers, tomllib
@@ -19,11 +20,11 @@ class PipenvCollector(Collector):
 
     name = "pipenv"
 
-    def __init__(self, pipfile, category):
+    def __init__(self, pipfile: str | Path, category: str) -> None:
         self.pipfile = Path(pipfile)
         self.category = category
 
-    def collect(self):
+    def collect(self) -> Iterator[str]:
         with self.pipfile.open("rb") as f:
             pipfile_data = tomllib.load(f)
 

--- a/src/pyproject_installer/deps_cmd/collectors/poetry.py
+++ b/src/pyproject_installer/deps_cmd/collectors/poetry.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterator
 from pathlib import Path
 
 from ...lib import is_pep508_requirement, markers, tomllib
@@ -20,10 +21,10 @@ class PoetryCollector(Collector):
 
     name = "poetry"
 
-    def __init__(self, group):
+    def __init__(self, group: str) -> None:
         self.group = group
 
-    def collect(self):
+    def collect(self) -> Iterator[str]:
         pyproject_file = Path.cwd() / "pyproject.toml"
 
         with pyproject_file.open("rb") as f:

--- a/src/pyproject_installer/deps_cmd/collectors/tox.py
+++ b/src/pyproject_installer/deps_cmd/collectors/tox.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterator
 from configparser import ConfigParser
 from pathlib import Path
 
@@ -22,11 +23,11 @@ class ToxCollector(Collector):
 
     name = "tox"
 
-    def __init__(self, toxconfig, testenv):
+    def __init__(self, toxconfig: str | Path, testenv: str) -> None:
         self.toxconfig = Path(toxconfig)
         self.testenv = testenv
 
-    def _tox_config(self):
+    def _tox_config(self) -> ConfigParser:
         config = ConfigParser(interpolation=None)
         if self.toxconfig.suffix == ".toml":
             # pyproject.toml
@@ -46,7 +47,7 @@ class ToxCollector(Collector):
                 config.read_file(f)
         return config
 
-    def collect(self):
+    def collect(self) -> Iterator[str]:
         config = self._tox_config()
         try:
             testenv = config[self.testenv]

--- a/src/pyproject_installer/deps_cmd/deps_config.py
+++ b/src/pyproject_installer/deps_cmd/deps_config.py
@@ -33,12 +33,8 @@ class DepsConfigType(TypedDict):
     sources: dict[str, DepsConfigSourceSpec]
 
 
-def get_identifiers(template: Template) -> list[str]:
-    """Compat get_identifiers (added in Python 3.11)"""
-    if hasattr(template, "get_identifiers"):
-        return template.get_identifiers()  # type: ignore[no-any-return]
-
-    # taken from CPython 3.11
+def _get_identifiers_py310(template: Template) -> list[str]:  # pragma: no cover
+    """Backport of CPython 3.11 Template.get_identifiers for Python 3.10."""
     ids = []
     for mo in template.pattern.finditer(template.template):
         named = mo.group("named") or mo.group("braced")
@@ -54,6 +50,13 @@ def get_identifiers(template: Template) -> list[str]:
                 template.pattern,
             )
     return ids
+
+
+def get_identifiers(template: Template) -> list[str]:
+    """Compat get_identifiers (added in Python 3.11)"""
+    if hasattr(template, "get_identifiers"):  # pragma: no cover
+        return template.get_identifiers()  # type: ignore[no-any-return]
+    return _get_identifiers_py310(template)  # pragma: no cover
 
 
 class DepsSourcesConfig:

--- a/src/pyproject_installer/deps_cmd/deps_config.py
+++ b/src/pyproject_installer/deps_cmd/deps_config.py
@@ -1,22 +1,42 @@
 import json
 import re
 import sys
+from collections.abc import Iterator, Mapping
 from copy import deepcopy
 from pathlib import Path
 from string import Template
+from typing import Any, TypedDict
 
 from ..errors import DepsSourcesConfigError, DepsUnsyncedError
 from ..lib import is_pep508_requirement, requirements
 from ..lib.normalization import pep503_normalized_name
 from .collectors import get_collector
+from .collectors.collector import Collector
 
 DEFAULT_CONFIG_NAME = "pyproject_deps.json"
 
 
-def get_identifiers(template):
+class DepsConfigSourceBaseType(TypedDict):
+    srctype: str
+
+
+class DepsConfigSourceOptType(TypedDict, total=False):
+    deps: tuple[str, ...]
+    srcargs: tuple[str, ...]
+
+
+class DepsConfigSourceSpec(DepsConfigSourceBaseType, DepsConfigSourceOptType):
+    pass
+
+
+class DepsConfigType(TypedDict):
+    sources: dict[str, DepsConfigSourceSpec]
+
+
+def get_identifiers(template: Template) -> list[str]:
     """Compat get_identifiers (added in Python 3.11)"""
     if hasattr(template, "get_identifiers"):
-        return template.get_identifiers()
+        return template.get_identifiers()  # type: ignore[no-any-return]
 
     # taken from CPython 3.11
     ids = []
@@ -37,13 +57,13 @@ def get_identifiers(template):
 
 
 class DepsSourcesConfig:
-    def __init__(self, file=None):
+    def __init__(self, file: str | Path | None = None) -> None:
         self.file = (
             Path.cwd() / DEFAULT_CONFIG_NAME if file is None else Path(file)
         )
-        self._config = None
+        self._config: DepsConfigType | None = None
 
-    def validate_config(self, config):
+    def validate_config(self, config: DepsConfigType) -> None:
         """Very basic validation of required fields"""
         if not isinstance(config, dict):
             raise DepsSourcesConfigError(
@@ -78,7 +98,7 @@ class DepsSourcesConfig:
                     ) from None
 
     @property
-    def config(self):
+    def config(self) -> DepsConfigType:
         if self._config is None:
             with self.file.open(encoding="utf-8") as f:
                 try:
@@ -92,37 +112,42 @@ class DepsSourcesConfig:
         return self._config
 
     @config.setter
-    def config(self, value):
+    def config(self, value: DepsConfigType) -> None:
         self._config = deepcopy(value)
         self.save()
 
-    def set_default(self):
+    def set_default(self) -> None:
         # default config
         self.config = {"sources": {}}
 
-    def save(self):
+    def save(self) -> None:
         self.validate_config(self.config)
         # first parse the whole config
         json_config = self._to_json(self.config)
         self.file.write_text(json_config, encoding="utf-8")
 
-    def show(self, srcnames=()):
-        show_conf = {"sources": {}}
+    def show(self, srcnames: tuple[str, ...] = ()) -> None:
+        show_conf: DepsConfigType = {"sources": {}}
         for srcname, source in self.iter_sources(srcnames):
             show_conf["sources"][srcname] = source
         self._show(show_conf)
 
-    def _to_json(self, conf):
+    def _to_json(self, conf: Mapping[str, Any]) -> str:
         return json.dumps(conf, indent=2, sort_keys=True) + "\n"
 
-    def _show(self, conf):
+    def _show(self, conf: Mapping[str, Any]) -> None:
         sys.stdout.write(self._to_json(conf))
 
     @property
-    def sources(self):
+    def sources(self) -> dict[str, DepsConfigSourceSpec]:
         return self.config["sources"]
 
-    def add(self, srcname, srctype, srcargs=()):
+    def add(
+        self,
+        srcname: str,
+        srctype: str,
+        srcargs: tuple[str, ...] = (),
+    ) -> None:
         if not self.file.is_file():
             # allow new file
             self.set_default()
@@ -136,13 +161,16 @@ class DepsSourcesConfig:
             self.sources[srcname]["srcargs"] = srcargs
         self.save()
 
-    def delete(self, srcname):
+    def delete(self, srcname: str) -> None:
         if srcname not in self.sources:
             raise ValueError(f"Source {srcname} doesn't exist")
         del self.sources[srcname]
         self.save()
 
-    def iter_sources(self, srcnames=()):
+    def iter_sources(
+        self,
+        srcnames: tuple[str, ...] = (),
+    ) -> Iterator[tuple[str, DepsConfigSourceSpec]]:
         if missing_srcnames := [x for x in srcnames if x not in self.sources]:
             raise ValueError(
                 f"Nonexistent sources: {', '.join(missing_srcnames)}",
@@ -151,7 +179,11 @@ class DepsSourcesConfig:
         for srcname in srcnames or self.sources:
             yield srcname, self.sources[srcname]
 
-    def validate_collector(self, srctype, srcargs):
+    def validate_collector(
+        self,
+        srctype: str,
+        srcargs: tuple[str, ...],
+    ) -> Collector:
         collector_cls = get_collector(srctype)
         if collector_cls is None:
             raise DepsSourcesConfigError(
@@ -164,11 +196,17 @@ class DepsSourcesConfig:
                 f"Unsupported arguments of collector {srctype}: {e!s}",
             ) from None
 
-    def collect(self, srctype, srcargs):
+    def collect(self, srctype: str, srcargs: tuple[str, ...]) -> Iterator[str]:
         collector = self.validate_collector(srctype, srcargs)
         return collector.collect()
 
-    def sync(self, *, srcnames=(), verify=False, verify_excludes=()):
+    def sync(
+        self,
+        *,
+        srcnames: tuple[str, ...] = (),
+        verify: bool = False,
+        verify_excludes: tuple[str, ...] = (),
+    ) -> None:
         """Sync sources
 
         verify: do sync of selected sources, but print the diff on
@@ -180,10 +218,10 @@ class DepsSourcesConfig:
         if verify_excludes and not verify:
             raise ValueError("verify_excludes must be used with verify")
 
-        diff = {}
+        diff: dict[str, dict[str, list[str]]] = {}
         verify_excludes_regs = {re.compile(x) for x in verify_excludes}
 
-        def filter_verify_excludes(req):
+        def filter_verify_excludes(req: requirements.Requirement) -> bool:
             """filter diff output"""
             req_name = pep503_normalized_name(req.name)
             return not any(reg.match(req_name) for reg in verify_excludes_regs)
@@ -206,7 +244,7 @@ class DepsSourcesConfig:
             if stored_deps == synced_deps:
                 continue
 
-            source["deps"] = sorted(map(str, synced_deps))
+            source["deps"] = tuple(sorted(map(str, synced_deps)))
 
             if not verify:
                 continue
@@ -232,7 +270,12 @@ class DepsSourcesConfig:
             self._show(diff)
             raise DepsUnsyncedError
 
-    def depformat(self, req, depformat, depformatextra):
+    def depformat(
+        self,
+        req: requirements.Requirement,
+        depformat: str,
+        depformatextra: str | None,
+    ) -> Iterator[str]:
         template = Template(depformat)
         identifiers = get_identifiers(template)
 
@@ -259,12 +302,12 @@ class DepsSourcesConfig:
     def eval(
         self,
         *,
-        srcnames=(),
-        depformat=None,
-        depformatextra=None,
-        extra=None,
-        excludes=(),
-    ):
+        srcnames: tuple[str, ...] = (),
+        depformat: str | None = None,
+        depformatextra: str | None = None,
+        extra: str | None = None,
+        excludes: tuple[str, ...] = (),
+    ) -> None:
         if depformatextra is not None and depformat is None:
             raise ValueError("depformatextra must be used with depformat")
         deps = set()

--- a/src/pyproject_installer/install_cmd/_install.py
+++ b/src/pyproject_installer/install_cmd/_install.py
@@ -2,8 +2,10 @@ import logging
 import shutil
 import sys
 import sysconfig
+from collections.abc import Callable, Iterable, Iterator
 from importlib.metadata import PathDistribution
 from pathlib import Path
+from typing import Literal
 
 from pyproject_installer.install_cmd._rpm_filelist import (
     write_rpm_filelist,
@@ -22,11 +24,11 @@ logger = logging.getLogger(__name__)
 
 MAGIC_SHEBANG = b"#!python"
 
-ALLOW_DIST_INFO_LIST = ("METADATA", "entry_points.txt")
-DENY_DIST_INFO_LIST = ("RECORD",)
+ALLOW_DIST_INFO_LIST: tuple[str, ...] = ("METADATA", "entry_points.txt")
+DENY_DIST_INFO_LIST: tuple[str, ...] = ("RECORD",)
 
 
-def get_installation_scheme(dist_name):
+def get_installation_scheme(dist_name: str) -> dict[str, str]:
     scheme_dict = sysconfig.get_paths()
 
     # there is no headers in sysconfig for now
@@ -47,7 +49,13 @@ def get_installation_scheme(dist_name):
     return scheme_dict
 
 
-def install_wheel_data(data_path, scheme, destdir, *, installed_paths=None):
+def install_wheel_data(
+    data_path: Path,
+    scheme: dict[str, str],
+    destdir: Path,
+    *,
+    installed_paths: set[Path] | None = None,
+) -> None:
     """
     PEP427:
     Each subdirectory of distribution-1.0.data/ is a key into a dict of
@@ -63,13 +71,15 @@ def install_wheel_data(data_path, scheme, destdir, *, installed_paths=None):
     """
     logger.info("Installing .data")
 
+    copy_fn: Callable[[str, str], str]
     if installed_paths is None:
         copy_fn = shutil.copy2
     else:
 
-        def copy_fn(src, dst):
-            shutil.copy2(src, dst)
+        def copy_fn(src: str, dst: str) -> str:
+            new_file = shutil.copy2(src, dst)
             installed_paths.add(Path(dst))
+            return new_file
 
     # keys of .data dir were prechecked in `validate`
     for f in data_path.iterdir():
@@ -111,7 +121,7 @@ def install_wheel_data(data_path, scheme, destdir, *, installed_paths=None):
     shutil.rmtree(data_path)
 
 
-def validate_wheel_path(wheel_path):
+def validate_wheel_path(wheel_path: Path) -> Path:
     try:
         wheel_path = wheel_path.resolve(strict=True)
     except (FileNotFoundError, RuntimeError):
@@ -121,7 +131,7 @@ def validate_wheel_path(wheel_path):
     return wheel_path
 
 
-def validate_destdir(destdir):
+def validate_destdir(destdir: Path) -> Path:
     try:
         destdir.mkdir(parents=True, exist_ok=True)
     except PermissionError:
@@ -132,7 +142,12 @@ def validate_destdir(destdir):
     return destdir.resolve(strict=True)
 
 
-def filter_dist_info(dist_info, *, members, strip_dist_info=True):
+def filter_dist_info(
+    dist_info: str,
+    *,
+    members: Iterable[str],
+    strip_dist_info: bool = True,
+) -> Iterator[str]:
     """
     If `strip_dist_info` is True then only `allow_list` is allowed in
     dist-info directory. The `deny_list` is unconditionally filtered out.
@@ -156,14 +171,14 @@ def filter_dist_info(dist_info, *, members, strip_dist_info=True):
 
 
 def install_wheel(
-    wheel_path,
+    wheel_path: Path,
     *,
-    destdir,
-    installer=None,
-    strip_dist_info=True,
-    rpm_filelist=None,
-    force_site=None,
-):
+    destdir: Path,
+    installer: str | None = None,
+    strip_dist_info: bool = True,
+    rpm_filelist: Path | None = None,
+    force_site: Literal["purelib", "platlib"] | None = None,
+) -> None:
     wheel_path = validate_wheel_path(wheel_path)
     destdir = validate_destdir(destdir)
 
@@ -198,7 +213,9 @@ def install_wheel(
             ),
         )
 
-        installed_paths = set() if rpm_filelist is not None else None
+        installed_paths: set[Path] | None = (
+            set() if rpm_filelist is not None else None
+        )
 
         logger.info("Extracting wheel")
         whl.extract(rootdir, members=members)
@@ -240,7 +257,7 @@ def install_wheel(
             installed_paths=installed_paths,
         )
 
-    if installed_paths is not None:
+    if rpm_filelist is not None and installed_paths is not None:
         write_rpm_filelist(
             rpm_filelist,
             installed_paths,

--- a/src/pyproject_installer/install_cmd/_rpm_filelist.py
+++ b/src/pyproject_installer/install_cmd/_rpm_filelist.py
@@ -14,6 +14,7 @@ to `write_rpm_filelist`.
 """
 
 import sys
+from collections.abc import Iterable
 from importlib.util import cache_from_source
 from itertools import chain
 from pathlib import Path
@@ -21,7 +22,7 @@ from pathlib import Path
 # Standard CPython optimization levels per PEP 488; argument to
 # importlib.util.cache_from_source. Not exposed as a stdlib constant,
 # so duplicated here with a single source of truth.
-PYC_OPTIMIZATION_LEVELS = ("", "1", "2")
+PYC_OPTIMIZATION_LEVELS: tuple[str, ...] = ("", "1", "2")
 
 # Compression extensions brp-compress decompresses on a man page.
 # If the wheel ships the page with one of these, brp will then
@@ -33,7 +34,13 @@ PYC_OPTIMIZATION_LEVELS = ("", "1", "2")
 MAN_COMPRESSION_SUFFIXES = frozenset({".gz", ".bz2", ".Z"})
 
 
-def render_rpm_filelist(files, *, destdir, scheme, dist_info):
+def render_rpm_filelist(
+    files: Iterable[str | Path],
+    *,
+    destdir: str | Path,
+    scheme: dict[str, str],
+    dist_info: str | Path,
+) -> str:
     """
     Return an RPM %files-compatible filelist body for ``files``.
 
@@ -173,7 +180,7 @@ def render_rpm_filelist(files, *, destdir, scheme, dist_info):
                 for o in PYC_OPTIMIZATION_LEVELS
             )
 
-    def render_file(p):
+    def render_file(p: Path) -> str:
         rp = str(p)
 
         # brp-compress compresses uncompressed man pages after %install
@@ -199,7 +206,14 @@ def render_rpm_filelist(files, *, destdir, scheme, dist_info):
     return "\n".join(lines) + "\n"
 
 
-def write_rpm_filelist(out_path, files, *, destdir, scheme, dist_info):
+def write_rpm_filelist(
+    out_path: str | Path,
+    files: Iterable[str | Path],
+    *,
+    destdir: str | Path,
+    scheme: dict[str, str],
+    dist_info: str | Path,
+) -> None:
     """
     Render the filelist for ``files`` and write it to ``out_path``.
     Permissions follow the process umask.

--- a/src/pyproject_installer/lib/__init__.py
+++ b/src/pyproject_installer/lib/__init__.py
@@ -1,9 +1,9 @@
 import contextlib
+import sys
 
-try:
-    # Python 3.11+
+if sys.version_info >= (3, 11):
     import tomllib
-except ModuleNotFoundError:
+else:
     from .._vendor import tomli as tomllib
 
 from .._vendor.packaging import (
@@ -27,7 +27,7 @@ __all__ = [
 ]
 
 
-def is_pep508_requirement(requirement):
+def is_pep508_requirement(requirement: str) -> bool:
     """
     Returns True if string requirement is valid PEP508 specifier
     https://packaging.python.org/en/latest/specifications/dependency-specifiers/#dependency-specifiers

--- a/src/pyproject_installer/lib/__init__.py
+++ b/src/pyproject_installer/lib/__init__.py
@@ -1,9 +1,9 @@
 import contextlib
 import sys
 
-if sys.version_info >= (3, 11):
+if sys.version_info >= (3, 11):  # pragma: no cover
     import tomllib
-else:
+else:  # pragma: no cover
     from .._vendor import tomli as tomllib
 
 from .._vendor.packaging import (

--- a/src/pyproject_installer/lib/backend_helper/backend_caller.py
+++ b/src/pyproject_installer/lib/backend_helper/backend_caller.py
@@ -10,11 +10,19 @@ import os
 import sys
 from importlib import import_module
 from pathlib import Path
+from typing import Any, Literal, TypedDict, overload
 
 logger = logging.getLogger(Path(__file__).name)
 
 # hook name: fallback (None - mandatory hook)
-SUPPORTED_HOOKS = {
+HookResultType = list[str] | str | None
+BuildWheelResultType = str
+BuildSdistResultType = str
+RequiresBuildWheelResultType = list[str]
+RequiresBuildSdistResultType = list[str]
+PrepareMetadataResultType = str
+
+SUPPORTED_HOOKS: dict[str, HookResultType] = {
     "build_wheel": None,
     "build_sdist": None,
     "get_requires_for_build_wheel": [],
@@ -24,7 +32,36 @@ SUPPORTED_HOOKS = {
 }
 
 
-def backend_object(backend, backend_path=None):
+class BackendBuildWheelType(TypedDict):
+    result: BuildWheelResultType
+
+
+class BackendBuildSdistType(TypedDict):
+    result: BuildSdistResultType
+
+
+class BackendRequiresBuildWheelType(TypedDict):
+    result: RequiresBuildWheelResultType
+
+
+class BackendRequiresBuildSdistType(TypedDict):
+    result: RequiresBuildSdistResultType
+
+
+class BackendPrepareMetadataType(TypedDict):
+    result: PrepareMetadataResultType
+
+
+BackendResultType = (
+    BackendBuildWheelType
+    | BackendBuildSdistType
+    | BackendRequiresBuildWheelType
+    | BackendRequiresBuildSdistType
+    | BackendPrepareMetadataType
+)
+
+
+def backend_object(backend: str, backend_path: list[str] | None = None) -> Any:
     if backend_path is not None:
         # Projects can specify that their backend code is hosted in-tree by
         # including the backend-path key in pyproject.toml. This key contains a
@@ -42,7 +79,13 @@ def backend_object(backend, backend_path=None):
         # Front ends MAY enforce this check, but are not required to. Doing so
         # would typically involve checking the backend's __file__ attribute
         # against the locations in backend-path.
-        actual_bep = Path(backend_obj.__file__).resolve(strict=True)
+        backend_file = backend_obj.__file__
+        if backend_file is None:
+            raise ValueError(
+                f"Backend {backend!r} has no __file__ location; "
+                f"cannot enforce backend-path",
+            )
+        actual_bep = Path(backend_file).resolve(strict=True)
         for path in backend_path:
             expected_bep = Path(path).resolve(strict=True)
 
@@ -66,14 +109,14 @@ def backend_object(backend, backend_path=None):
     return backend_obj
 
 
-def write_result(result_fd, result):
-    result = result.encode("utf-8")
+def write_result(result_fd: int, result: str) -> None:
+    payload = result.encode("utf-8")
     sent = 0
-    while sent != len(result):
-        sent += os.write(result_fd, result[sent:])
+    while sent != len(payload):
+        sent += os.write(result_fd, payload[sent:])
 
 
-def main_parser(prog):
+def main_parser(prog: str) -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="PEP517 hook caller in subprocess",
         prog=prog,
@@ -114,12 +157,12 @@ def main_parser(prog):
     return parser
 
 
-def emit_less_than_warning(record):
+def emit_less_than_warning(record: logging.LogRecord) -> bool:
     # nonzero if record should be logged
     return record.levelno < logging.WARNING
 
 
-def setup_logging(*, verbose=False):
+def setup_logging(*, verbose: bool = False) -> None:
     # emit WARNING, ERROR and CRITICAL to stderr
     stderr_handler = logging.StreamHandler(sys.stderr)
     stderr_handler.setLevel(logging.WARNING)
@@ -142,7 +185,63 @@ def setup_logging(*, verbose=False):
     )
 
 
-def call_hook(backend, backend_path, hook, hook_args, hook_kwargs):
+@overload
+def call_hook(
+    backend: str,
+    backend_path: list[str] | None,
+    hook: Literal["build_wheel"],
+    hook_args: list[str],
+    hook_kwargs: dict[str, Any],
+) -> BuildWheelResultType: ...
+
+
+@overload
+def call_hook(
+    backend: str,
+    backend_path: list[str] | None,
+    hook: Literal["build_sdist"],
+    hook_args: list[str],
+    hook_kwargs: dict[str, Any],
+) -> BuildSdistResultType: ...
+
+
+@overload
+def call_hook(
+    backend: str,
+    backend_path: list[str] | None,
+    hook: Literal["get_requires_for_build_wheel"],
+    hook_args: list[str],
+    hook_kwargs: dict[str, Any],
+) -> RequiresBuildWheelResultType: ...
+
+
+@overload
+def call_hook(
+    backend: str,
+    backend_path: list[str] | None,
+    hook: Literal["get_requires_for_build_sdist"],
+    hook_args: list[str],
+    hook_kwargs: dict[str, Any],
+) -> RequiresBuildSdistResultType: ...
+
+
+@overload
+def call_hook(
+    backend: str,
+    backend_path: list[str] | None,
+    hook: Literal["prepare_metadata_for_build_wheel"],
+    hook_args: list[str],
+    hook_kwargs: dict[str, Any],
+) -> PrepareMetadataResultType: ...
+
+
+def call_hook(
+    backend: str,
+    backend_path: list[str] | None,
+    hook: str,
+    hook_args: list[str],
+    hook_kwargs: dict[str, Any],
+) -> HookResultType:
     hook_obj = backend_object(backend, backend_path=backend_path)
     try:
         hook_func = getattr(hook_obj, hook)
@@ -154,10 +253,11 @@ def call_hook(backend, backend_path, hook, hook_args, hook_kwargs):
             ) from None
         return fallback
 
-    return hook_func(*hook_args, **hook_kwargs)
+    result: HookResultType = hook_func(*hook_args, **hook_kwargs)
+    return result
 
 
-def main(cli_args, prog=Path(__file__).name):
+def main(cli_args: list[str], prog: str = Path(__file__).name) -> None:
     parser = main_parser(prog)
     args = parser.parse_args(cli_args)
     setup_logging(verbose=args.verbose)

--- a/src/pyproject_installer/lib/build_backend.py
+++ b/src/pyproject_installer/lib/build_backend.py
@@ -5,8 +5,17 @@ import subprocess
 import threading
 from contextlib import suppress
 from pathlib import Path
+from typing import Any, Literal, TypedDict, overload
 
 from . import tomllib
+from .backend_helper.backend_caller import (
+    BackendBuildSdistType,
+    BackendBuildWheelType,
+    BackendPrepareMetadataType,
+    BackendRequiresBuildSdistType,
+    BackendRequiresBuildWheelType,
+    BackendResultType,
+)
 
 __all__ = [
     "backend_hook",
@@ -15,28 +24,55 @@ __all__ = [
 
 logger = logging.getLogger(__name__)
 
-BACKEND_CALLER = Path(__file__).parent / "backend_helper" / "backend_caller.py"
+BACKEND_CALLER = str(
+    Path(__file__).parent / "backend_helper" / "backend_caller.py",
+)
 
 
 class RaisingThread(threading.Thread):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        self._exc = None
+        self._exc: BaseException | None = None
 
-    def run(self, *args, **kwargs):
+    def run(self, *args: Any, **kwargs: Any) -> None:
         self._exc = None
         try:
             super().run(*args, **kwargs)
         except BaseException as e:  # noqa: BLE001
             self._exc = e
 
-    def join(self, *args, **kwargs):
+    def join(self, *args: Any, **kwargs: Any) -> None:
         super().join(*args, **kwargs)
         if self._exc:
             raise self._exc
 
 
-def parse_build_system_spec(srcdir):
+BuildSystemTypeBase = TypedDict(
+    "BuildSystemTypeBase",
+    {
+        "build-backend": str,
+        "requires": list[str],
+    },
+)
+
+
+BuildSystemOptType = TypedDict(
+    "BuildSystemOptType",
+    {
+        "backend-path": list[str],
+    },
+    total=False,
+)
+
+
+# pylint can't see that TypedDict() functional calls produce class-like
+# objects, so it flags inherit-non-class / duplicate-bases here.
+# pylint: disable-next=inherit-non-class,duplicate-bases
+class BuildSystemType(BuildSystemTypeBase, BuildSystemOptType):
+    pass
+
+
+def parse_build_system_spec(srcdir: Path) -> BuildSystemType:
     """
     PEP517 spec: https://peps.python.org/pep-0517/#source-trees.
 
@@ -61,7 +97,7 @@ def parse_build_system_spec(srcdir):
     """
     logger.debug("Checking for PEP517 spec")
     pyproject_file = srcdir / "pyproject.toml"
-    default_build_system = {
+    default_build_system: BuildSystemType = {
         "build-backend": "setuptools.build_meta:__legacy__",
         "requires": ["setuptools"],
     }
@@ -119,7 +155,7 @@ def parse_build_system_spec(srcdir):
             f"build-backend should be a string, given: {build_backend!r}",
         )
 
-    bs = {
+    bs: BuildSystemType = {
         "build-backend": build_backend,
         "requires": requires,
     }
@@ -183,13 +219,13 @@ def parse_build_system_spec(srcdir):
 
 def make_helper_args(
     *,
-    python,
-    result_fd,
-    verbose,
-    build_system,
-    hook,
-    hook_args,
-):
+    python: str,
+    result_fd: int,
+    verbose: bool,
+    build_system: BuildSystemType,
+    hook: str,
+    hook_args: tuple[tuple[str, ...], dict[str, Any]],
+) -> list[str]:
     args = [
         python,
         BACKEND_CALLER,
@@ -209,7 +245,7 @@ def make_helper_args(
     return args
 
 
-def validate_source_dir(srcdir):
+def validate_source_dir(srcdir: Path) -> Path:
     """Resolve and validate source path"""
     logger.debug("Validating source path")
     try:
@@ -232,7 +268,69 @@ def validate_source_dir(srcdir):
     return srcdir
 
 
-def backend_hook(python, srcdir, verbose, hook, hook_args=((), {})):
+@overload
+def backend_hook(
+    python: str,
+    srcdir: Path,
+    *,
+    verbose: bool,
+    hook: Literal["build_wheel"],
+    hook_args: tuple[tuple[str, ...], dict[str, Any]] = ((), {}),
+) -> BackendBuildWheelType: ...
+
+
+@overload
+def backend_hook(
+    python: str,
+    srcdir: Path,
+    *,
+    verbose: bool,
+    hook: Literal["build_sdist"],
+    hook_args: tuple[tuple[str, ...], dict[str, Any]] = ((), {}),
+) -> BackendBuildSdistType: ...
+
+
+@overload
+def backend_hook(
+    python: str,
+    srcdir: Path,
+    *,
+    verbose: bool,
+    hook: Literal["get_requires_for_build_wheel"],
+    hook_args: tuple[tuple[str, ...], dict[str, Any]] = ((), {}),
+) -> BackendRequiresBuildWheelType: ...
+
+
+@overload
+def backend_hook(
+    python: str,
+    srcdir: Path,
+    *,
+    verbose: bool,
+    hook: Literal["get_requires_for_build_sdist"],
+    hook_args: tuple[tuple[str, ...], dict[str, Any]] = ((), {}),
+) -> BackendRequiresBuildSdistType: ...
+
+
+@overload
+def backend_hook(
+    python: str,
+    srcdir: Path,
+    *,
+    verbose: bool,
+    hook: Literal["prepare_metadata_for_build_wheel"],
+    hook_args: tuple[tuple[str, ...], dict[str, Any]] = ((), {}),
+) -> BackendPrepareMetadataType: ...
+
+
+def backend_hook(
+    python: str,
+    srcdir: Path,
+    *,
+    verbose: bool,
+    hook: str,
+    hook_args: tuple[tuple[str, ...], dict[str, Any]] = ((), {}),
+) -> BackendResultType:
     srcdir = validate_source_dir(srcdir)
     build_system = parse_build_system_spec(srcdir)
     read = b""
@@ -241,7 +339,7 @@ def backend_hook(python, srcdir, verbose, hook, hook_args=((), {})):
 
     try:
 
-        def read_from_pipe():
+        def read_from_pipe() -> None:
             nonlocal read
             buffer_size = 2048
             while True:
@@ -290,7 +388,7 @@ def backend_hook(python, srcdir, verbose, hook, hook_args=((), {})):
             raise RuntimeError(str(e)) from e
         os.close(rfd)
         try:
-            result = json.loads(read.decode("utf-8"))
+            result: BackendResultType = json.loads(read.decode("utf-8"))
         except json.JSONDecodeError:
             raise RuntimeError(
                 "Received invalid JSON data from backend helper: "

--- a/src/pyproject_installer/lib/normalization.py
+++ b/src/pyproject_installer/lib/normalization.py
@@ -1,7 +1,7 @@
 from . import utils
 
 
-def pep503_normalized_name(name):
+def pep503_normalized_name(name: str) -> utils.NormalizedName:
     """
     PEP503 normalized names
     https://peps.python.org/pep-0503/#normalized-names

--- a/src/pyproject_installer/lib/scripts.py
+++ b/src/pyproject_installer/lib/scripts.py
@@ -1,4 +1,6 @@
 import logging
+from importlib.metadata import Distribution
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -17,7 +19,7 @@ if __name__ == "__main__":
 SHEBANG_LENGTH_LIMIT = 127
 
 
-def build_shebang(executable):
+def build_shebang(executable: str) -> str:
     """
     man 2 execve
     The kernel imposes a maximum length on the text that follows the
@@ -34,13 +36,13 @@ def build_shebang(executable):
 
 
 def generate_entrypoints_scripts(
-    distr,
-    python,
-    scriptsdir,
-    destdir,
+    distr: Distribution,
+    python: str,
+    scriptsdir: Path,
+    destdir: str | Path,
     *,
-    installed_paths=None,
-):
+    installed_paths: set[Path] | None = None,
+) -> None:
     """
     Optional entry_points
     https://packaging.python.org/en/latest/specifications/entry-points/

--- a/src/pyproject_installer/lib/wheel.py
+++ b/src/pyproject_installer/lib/wheel.py
@@ -2,10 +2,13 @@ import base64
 import csv
 import hashlib
 import logging
+from collections.abc import Collection, Iterator
+from email.message import Message as EmailMessage
 from email.parser import Parser
 from importlib.metadata import PathDistribution
 from io import TextIOWrapper
 from pathlib import Path
+from types import TracebackType
 from zipfile import BadZipFile, ZipFile
 from zipfile import Path as ZipPath
 
@@ -19,12 +22,12 @@ WHEEL_SPECIFICATION_VERSION = (1, 0)
 RECORD_FIELDS_NUMBER = 3
 
 
-def digest_for_record(name, data):
+def digest_for_record(name: str, data: bytes) -> str:
     digest = hashlib.new(name, data).digest()
     return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
 
 
-def parse_name(name):
+def parse_name(name: str) -> tuple[str, str]:
     """Parse wheel's name"""
     supported_format = (
         "{distribution}-{version}(-{build tag})?-{python tag}-{abi tag}-"
@@ -53,8 +56,8 @@ def parse_name(name):
 
 
 class WheelFile:
-    def __init__(self, wheel_path):
-        self._zipfile = None
+    def __init__(self, wheel_path: str | Path) -> None:
+        self._zipfile: ZipFile | None = None
         try:
             self._zipfile = ZipFile(wheel_path)
         except BadZipFile as e:
@@ -78,20 +81,20 @@ class WheelFile:
         )
         self.data_name = f"{self.dist_name}-{self.dist_version}.data"
         self.data = self.root / self.data_name
-        self._wheel_metadata = None
+        self._wheel_metadata: EmailMessage | None = None
         self.validate()
 
     @property
-    def memberlist(self):
+    def memberlist(self) -> Iterator[str]:
         yield from self._memberlist
 
     @property
-    def wheel_metadata(self):
+    def wheel_metadata(self) -> EmailMessage:
         if self._wheel_metadata is None:
             self._wheel_metadata = self.parse_wheel_metadata()
         return self._wheel_metadata
 
-    def validate(self):
+    def validate(self) -> None:
         """Validate wheel according to PEP427"""
         logger.debug("Validating wheel file")
 
@@ -105,7 +108,7 @@ class WheelFile:
         if self.data.exists():
             self.validate_data()
 
-    def validate_entry_points(self):
+    def validate_entry_points(self) -> None:
         """
         the name of the entry point should be usable as a command in a system
         shell after the package is installed. The object reference points to a
@@ -120,7 +123,7 @@ class WheelFile:
                         f"Invalid entry_points specification: {ep.value}",
                     )
 
-    def validate_data(self):
+    def validate_data(self) -> None:
         """
         Each subdirectory of distribution-1.0.data/ is a key into a dict of
         destination directories, such as
@@ -149,7 +152,7 @@ class WheelFile:
                 f"{', '.join(data_subpath_diff)}",
             )
 
-    def validate_record(self):
+    def validate_record(self) -> None:
         logger.debug("Validating RECORD")
         record_path = self.dist_info / "RECORD"
         recorded_files = set()
@@ -197,7 +200,11 @@ class WheelFile:
                 f"{', '.join(extra_packaged)}",
             )
 
-    def validate_hash_record(self, recorded_file, hash_info):
+    def validate_hash_record(
+        self,
+        recorded_file: str,
+        hash_info: str,
+    ) -> None:
         hash_name, _, hash_value = hash_info.partition("=")
         if not hash_name or not hash_value:
             raise ValueError(f"Invalid hash record: {hash_info}")
@@ -219,7 +226,7 @@ class WheelFile:
                 f"Incorrect hash for recorded file: {recorded_file}",
             )
 
-    def extraction_root(self, scheme):
+    def extraction_root(self, scheme: dict[str, str]) -> Path:
         """
         Root-Is-Purelib is true if the top level directory of the archive should
         be installed into purelib; otherwise the root should be installed into
@@ -231,7 +238,7 @@ class WheelFile:
             sitedir = "platlib"
         return Path(scheme[sitedir]).absolute()
 
-    def validate_wheel_spec_version(self):
+    def validate_wheel_spec_version(self) -> None:
         """
         A wheel installer should warn if Wheel-Version is greater than the
         version it supports, and must fail if Wheel-Version has a greater major
@@ -268,7 +275,7 @@ class WheelFile:
                 ".".join([str(i) for i in WHEEL_SPECIFICATION_VERSION]),
             )
 
-    def validate_dist_info(self):
+    def validate_dist_info(self) -> None:
         if not self.dist_info.exists() or not self.dist_info.is_dir():
             raise ValueError(
                 f"Missing mandatory dist-info directory: {self.dist_info}",
@@ -281,7 +288,7 @@ class WheelFile:
                     f"Missing mandatory {f} in dist-info directory",
                 )
 
-    def parse_wheel_metadata(self):
+    def parse_wheel_metadata(self) -> EmailMessage:
         """
         PEP427:
         METADATA and WHEEL are Metadata version 1.1 or greater format metadata.
@@ -295,24 +302,37 @@ class WheelFile:
 
         return Parser().parsestr(wheel_text)
 
-    def parse_name(self):
+    def parse_name(self) -> tuple[str, str]:
         logger.debug("Parsing wheel filename")
         return parse_name(self.name)
 
-    def extract(self, path, members=None):
+    def extract(
+        self,
+        path: str | Path,
+        members: Collection[str] | None = None,
+    ) -> None:
+        if self._zipfile is None:
+            raise WheelFileError(
+                "Wheel was not initialized properly before extraction",
+            )
         if members is None:
-            members = self.memberlist
+            members = tuple(self.memberlist)
         self._zipfile.extractall(path, members=members)
 
-    def __enter__(self):
+    def __enter__(self) -> "WheelFile":
         return self
 
-    def __exit__(self, exc_type, exc_value, traceback):
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
         self.close()
 
-    def close(self):
+    def close(self) -> None:
         if self._zipfile is not None:
             self._zipfile.close()
 
-    def __del__(self):
+    def __del__(self) -> None:
         self.close()

--- a/src/pyproject_installer/run_cmd/_run_command.py
+++ b/src/pyproject_installer/run_cmd/_run_command.py
@@ -1,3 +1,7 @@
+import subprocess
+from collections.abc import Sequence
+from pathlib import Path
+
 from pyproject_installer.errors import RunCommandEnvError
 
 from ._run_env import PyprojectVenv
@@ -5,7 +9,13 @@ from ._run_env import PyprojectVenv
 __all__ = ["run_command"]
 
 
-def run_command(wheel, *args, venv_name=".run_venv", **kwargs):
+def run_command(
+    wheel: str | Path,
+    *,
+    command: Sequence[str],
+    venv_name: str = ".run_venv",
+    capture_output: bool = False,
+) -> subprocess.CompletedProcess[bytes]:
     try:
         run_env = PyprojectVenv(wheel)
         run_env.create(venv_name)
@@ -13,4 +23,4 @@ def run_command(wheel, *args, venv_name=".run_venv", **kwargs):
         raise
     except Exception as e:
         raise RunCommandEnvError(str(e)) from e
-    return run_env.run(*args, **kwargs)
+    return run_env.run(command, capture_output=capture_output)

--- a/src/pyproject_installer/run_cmd/_run_env.py
+++ b/src/pyproject_installer/run_cmd/_run_env.py
@@ -3,8 +3,11 @@ import os
 import site
 import subprocess
 import sys
+from collections.abc import Sequence
 from importlib.metadata import distributions
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Protocol
 from venv import EnvBuilder
 
 from pyproject_installer.errors import RunCommandEnvError, RunCommandError
@@ -17,8 +20,19 @@ __all__ = ["PyprojectVenv"]
 logger = logging.getLogger(__name__)
 
 
+class VenvContextType(Protocol):
+    """Subset of the SimpleNamespace returned by EnvBuilder.ensure_directories
+    consumed by PyprojectVenv. See
+    https://docs.python.org/3/library/venv.html#venv.EnvBuilder.ensure_directories.
+    """
+
+    env_dir: str
+    bin_path: str
+    env_exec_cmd: str
+
+
 class PyprojectVenv(EnvBuilder):
-    def __init__(self, wheel):
+    def __init__(self, wheel: str | Path) -> None:
         """
         Build Python virtual environment
         - clean up existed environment on filesystem
@@ -26,23 +40,21 @@ class PyprojectVenv(EnvBuilder):
         - generate console scripts of system site packages
         - install package (wheel) into venv
         """
-        self.context = None
+        self.context: VenvContextType | None = None
         self.wheel = Path(wheel)
-        venv_kwargs = {
-            "system_site_packages": True,
-            "clear": True,
-            "upgrade": False,
-            "with_pip": False,
-            "upgrade_deps": False,
-        }
-        super().__init__(**venv_kwargs)
+        super().__init__(
+            system_site_packages=True,
+            clear=True,
+            upgrade=False,
+            with_pip=False,
+            upgrade_deps=False,
+        )
 
-    def ensure_directories(self, *args, **kwargs):
-        # save context for reusage
+    def ensure_directories(self, *args: Any, **kwargs: Any) -> SimpleNamespace:
         self.context = super().ensure_directories(*args, **kwargs)
         return self.context
 
-    def install_console_scripts(self, context):
+    def install_console_scripts(self, context: VenvContextType) -> None:
         """
         Install console_scripts of system and user site packages
 
@@ -100,7 +112,7 @@ class PyprojectVenv(EnvBuilder):
                     destdir="/",
                 )
 
-    def install_package(self, context):
+    def install_package(self, context: VenvContextType) -> None:
         """Install wheel into venv"""
         logger.info("Installing package: %s", self.wheel)
         install_args = [
@@ -115,7 +127,7 @@ class PyprojectVenv(EnvBuilder):
         except RunCommandError as e:
             raise RunCommandEnvError("Installation of package failed") from e
 
-    def create(self, *args, **kwargs):
+    def create(self, *args: Any, **kwargs: Any) -> None:
         """Calls `post_create` hook after `venv` creation
 
         base implementation of `create` disables system_site_packages
@@ -129,9 +141,13 @@ class PyprojectVenv(EnvBuilder):
         """
         logger.info("Creating venv")
         super().create(*args, **kwargs)
+        # context is populated on create -> ensure_directories
+        if self.context is None:
+            # should not be reachable
+            raise ValueError("Uninitialized context, create venv first")
         self.post_create(self.context)
 
-    def post_create(self, context):
+    def post_create(self, context: VenvContextType) -> None:
         """
         - generate console scripts of system and user site packages
         - install a wheel into venv
@@ -139,8 +155,11 @@ class PyprojectVenv(EnvBuilder):
         self.install_console_scripts(context)
         self.install_package(context)
 
-    def venv_environ(self):
+    def venv_environ(self) -> dict[str, str]:
         """Prepare environ for venv"""
+        # context is populated on create -> ensure_directories
+        if self.context is None:
+            raise ValueError("Uninitialized context, create venv first")
         env = os.environ.copy()
         try:
             current_path = env["PATH"]
@@ -151,7 +170,12 @@ class PyprojectVenv(EnvBuilder):
         env["VIRTUAL_ENV"] = self.context.env_dir
         return env
 
-    def run(self, command, *, capture_output=False):
+    def run(
+        self,
+        command: Sequence[str],
+        *,
+        capture_output: bool = False,
+    ) -> subprocess.CompletedProcess[bytes]:
         """Run a command in subprocess within venv"""
         logger.info("Running command: %r", command)
         try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,29 +1,37 @@
 import csv
 import shutil
 import textwrap
-from collections.abc import MutableMapping
+from collections.abc import Callable, Iterator, MutableMapping
 from io import StringIO
 from pathlib import Path
 from tempfile import mkdtemp
+from typing import Any
 from zipfile import ZipFile
 
 import pytest
 
 from pyproject_installer.lib.wheel import digest_for_record
 
+default_content_fields = [
+    "Metadata-Version: 2.1",
+    "Name: foo",
+    "Version: 1.0",
+]
 
-class WheelContents(MutableMapping):
+
+class WheelContents(MutableMapping[str, "str | bytes"]):
+
     def __init__(
         self,
         *,
-        distr="foo",
-        version="1.0",
-        purelib=True,
-        create_init=True,
-    ):
+        distr: str = "foo",
+        version: str = "1.0",
+        purelib: bool = True,
+        create_init: bool = True,
+    ) -> None:
         self.distinfo = f"{distr}-{version}.dist-info"
         self.record_key = f"{self.distinfo}/RECORD"
-        self._contents = {
+        self._contents: dict[str, str | bytes] = {
             **(
                 {
                     f"{distr}/__init__.py": textwrap.dedent(
@@ -59,14 +67,14 @@ class WheelContents(MutableMapping):
         self.update_record()
 
     @property
-    def record(self):
-        return self._contents[self.record_key]
+    def record(self) -> str:
+        return str(self._contents[self.record_key])
 
     @record.setter
-    def record(self, value):
+    def record(self, value: str) -> None:
         self._contents[self.record_key] = value
 
-    def update_record(self):
+    def update_record(self) -> None:
         with StringIO(newline="") as ws:
             writer = csv.writer(ws, lineterminator="\n")
             records = [
@@ -87,7 +95,7 @@ class WheelContents(MutableMapping):
             writer.writerows(records)
             self.record = ws.getvalue()
 
-    def drop_from_record(self, file):
+    def drop_from_record(self, file: str) -> None:
         with (
             StringIO(self.record, newline="") as rs,
             StringIO(newline="") as ws,
@@ -100,28 +108,28 @@ class WheelContents(MutableMapping):
 
             self.record = ws.getvalue()
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: str) -> str | bytes:
         return self._contents[key]
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: str, value: str | bytes) -> None:
         self._contents[key] = value
         if key != self.record_key:
             self.update_record()
 
-    def __delitem__(self, key):
+    def __delitem__(self, key: str) -> None:
         del self._contents[key]
         if key != self.record_key:
             self.update_record()
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[str]:
         return iter(self._contents)
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self._contents)
 
 
 @pytest.fixture
-def tmpdir(tmp_path):
+def tmpdir(tmp_path: Path) -> Iterator[Path]:
     yield tmp_path
     # Solaris: rmtree can't remove current working directory
     assert Path.cwd() != tmp_path
@@ -129,22 +137,22 @@ def tmpdir(tmp_path):
 
 
 @pytest.fixture
-def wheeldir(tmpdir):
+def wheeldir(tmpdir: Path) -> Path:
     wheeldir = tmpdir / "dist"
     wheeldir.mkdir()
     return wheeldir
 
 
 @pytest.fixture
-def destdir(tmpdir):
+def destdir(tmpdir: Path) -> Path:
     destdir = tmpdir / "destdir"
     destdir.mkdir()
     return destdir
 
 
 @pytest.fixture
-def pyproject(tmpdir):
-    def _pyproject(toml_text=None):
+def pyproject(tmpdir: Path) -> Callable[..., Path]:
+    def _pyproject(toml_text: str | None = None) -> Path:
         if toml_text is None:
             toml_text = textwrap.dedent(
                 """\
@@ -163,10 +171,13 @@ def pyproject(tmpdir):
 
 
 @pytest.fixture
-def pyproject_toml(pyproject, monkeypatch):
+def pyproject_toml(
+    pyproject: Callable[..., Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> Callable[[str], Path]:
     """Create pyproject.toml and cd to its directory"""
 
-    def _pyproject_toml(content):
+    def _pyproject_toml(content: str) -> Path:
         pyproject_path = pyproject(content)
         monkeypatch.chdir(pyproject_path)
         return pyproject_path
@@ -175,18 +186,21 @@ def pyproject_toml(pyproject, monkeypatch):
 
 
 @pytest.fixture
-def wheel_contents():
-    def _wheel_contents(**kwargs):
+def wheel_contents() -> Callable[..., WheelContents]:
+    def _wheel_contents(**kwargs: Any) -> WheelContents:
         return WheelContents(**kwargs)
 
     return _wheel_contents
 
 
 @pytest.fixture
-def wheel(tmpdir):
+def wheel(tmpdir: Path) -> Callable[..., Path]:
     """Prepares wheel file"""
 
-    def _wheel(name="foo-1.0-py3-none-any.whl", contents=None):
+    def _wheel(
+        name: str = "foo-1.0-py3-none-any.whl",
+        contents: dict[str, str | bytes] | None = None,
+    ) -> Path:
         if contents is None:
             contents = {}
         # make it possible to rebuild wheel during a test
@@ -203,10 +217,13 @@ def wheel(tmpdir):
 
 
 @pytest.fixture
-def pyproject_with_backend(pyproject, monkeypatch):
+def pyproject_with_backend(
+    pyproject: Callable[..., Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> Callable[[str], Path]:
     """Generates pyproject with self-hosted build backend"""
 
-    def _build_backend_src(be_content):
+    def _build_backend_src(be_content: str) -> Path:
         be_module = "be"
         pyproject_toml_content = textwrap.dedent(
             f"""\
@@ -229,15 +246,15 @@ def pyproject_with_backend(pyproject, monkeypatch):
 
 
 @pytest.fixture
-def pyproject_metadata(pyproject_with_backend):
+def pyproject_metadata(
+    pyproject_with_backend: Callable[[str], Path],
+) -> Callable[..., Path]:
     """Build backend with prepare_metadata_for_build_wheel"""
-    default_content_fields = [
-        "Metadata-Version: 2.1",
-        "Name: foo",
-        "Version: 1.0",
-    ]
 
-    def _core_metadata(headers=default_content_fields, reqs=()):
+    def _core_metadata(
+        headers: list[str] = default_content_fields,
+        reqs: tuple[str, ...] = (),
+    ) -> Path:
         content_fields = [
             *headers,
             *(f"Requires-Dist: {req}" for req in reqs),
@@ -273,15 +290,17 @@ def pyproject_metadata(pyproject_with_backend):
 
 
 @pytest.fixture
-def pyproject_metadata_wheel(pyproject_with_backend, wheel_contents, wheel):
+def pyproject_metadata_wheel(
+    pyproject_with_backend: Callable[[str], Path],
+    wheel_contents: Callable[..., WheelContents],
+    wheel: Callable[..., Path],
+) -> Callable[..., Path]:
     """Build backend with build_wheel only"""
-    default_content_fields = [
-        "Metadata-Version: 2.1",
-        "Name: foo",
-        "Version: 1.0",
-    ]
 
-    def _core_metadata(headers=default_content_fields, reqs=()):
+    def _core_metadata(
+        headers: list[str] = default_content_fields,
+        reqs: tuple[str, ...] = (),
+    ) -> Path:
         contents = wheel_contents()
         content_fields = list(headers)
         content_fields.extend(f"Requires-Dist: {x}" for x in reqs)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -2,7 +2,10 @@ import subprocess
 import sys
 import tempfile
 import textwrap
+from collections.abc import Callable, Iterator
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
 from venv import EnvBuilder
 
 import pytest
@@ -14,18 +17,19 @@ from pyproject_installer.lib.build_backend import backend_hook
 
 
 class ContextVenv(EnvBuilder):
-    def __init__(self, *args, **kwargs):
-        self.context = None
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.context: SimpleNamespace | None = None
         super().__init__(*args, **kwargs)
 
-    def ensure_directories(self, *args, **kwargs):
+    def ensure_directories(self, *args: Any, **kwargs: Any) -> SimpleNamespace:
         # save context for reusage
         self.context = super().ensure_directories(*args, **kwargs)
         return self.context
 
 
 @pytest.fixture(scope="session")
-def pyproject_installer_whl():
+def pyproject_installer_whl() -> Iterator[Path]:
     """Build pyproject_installer as wheel"""
     with tempfile.TemporaryDirectory() as d:
         wheels = Path(d) / "wheels"
@@ -36,7 +40,7 @@ def pyproject_installer_whl():
             "pyproject_installer",
             "build",
             "--outdir",
-            wheels,
+            str(wheels),
         ]
         subprocess.check_call(build_args)
         built_files = {f.name for f in wheels.iterdir()}
@@ -50,7 +54,7 @@ def pyproject_installer_whl():
 
 
 @pytest.fixture
-def virt_env(tmpdir):
+def virt_env(tmpdir: Path) -> SimpleNamespace:
     """Create virtual environment and returns its context
 
     https://docs.python.org/3/library/venv.html#venv.EnvBuilder.ensure_directories
@@ -58,11 +62,15 @@ def virt_env(tmpdir):
     venv_path = tmpdir / "venv"
     venv = ContextVenv(with_pip=True)
     venv.create(venv_path)
+    assert venv.context is not None
     return venv.context
 
 
 @pytest.fixture
-def virt_env_installer(virt_env, pyproject_installer_whl):
+def virt_env_installer(
+    virt_env: SimpleNamespace,
+    pyproject_installer_whl: Path,
+) -> SimpleNamespace:
     """Install pyproject_installer with pip into virtual env"""
     python = virt_env.env_exec_cmd
 
@@ -78,10 +86,10 @@ def virt_env_installer(virt_env, pyproject_installer_whl):
 
 
 @pytest.fixture
-def install_build_deps():
+def install_build_deps() -> Callable[[str, Path], None]:
     """Calc and install build deps of srcdir with pip"""
 
-    def _install_build_deps(python, srcdir):
+    def _install_build_deps(python: str, srcdir: Path) -> None:
         # get common build requirements(PEP518)
         with (srcdir / "pyproject.toml").open("rb") as f:
             pyproject_data = tomllib.load(f)
@@ -128,7 +136,7 @@ def install_build_deps():
 
 
 @pytest.fixture
-def setuptools_project(pyproject):
+def setuptools_project(pyproject: Callable[..., Path]) -> Path:
     pyproject_path = pyproject(
         textwrap.dedent(
             """\
@@ -154,7 +162,7 @@ def setuptools_project(pyproject):
 
 
 @pytest.fixture
-def pdm_project(pyproject):
+def pdm_project(pyproject: Callable[..., Path]) -> Path:
     return pyproject(
         textwrap.dedent(
             """\

--- a/tests/integration/test_rpm_filelist.py
+++ b/tests/integration/test_rpm_filelist.py
@@ -68,7 +68,9 @@ def test_rpmbuild_bl_accepts_generated_filelist(
     )
     compileall.compile_dir(
         str(purelib_buildroot),
-        optimize=[0, 1, 2],
+        # compileall.compile_dir does accept a list of optimization levels at
+        # runtime (compiles once per level); typeshed only documents int.
+        optimize=[0, 1, 2],  # type: ignore[arg-type]
         quiet=1,
     )
 
@@ -79,7 +81,7 @@ def test_rpmbuild_bl_accepts_generated_filelist(
     # Exit code is 0 when every listed path exists in the buildroot.
     subprocess.check_call(
         [
-            RPMBUILD,
+            RPMBUILD,  # type: ignore[list-item]
             "--buildroot=" + str(buildroot),
             "--define",
             f"_topdir {tmpdir}",

--- a/tests/unit/test_build/conftest.py
+++ b/tests/unit/test_build/conftest.py
@@ -1,10 +1,12 @@
 import json
+from unittest.mock import MagicMock
 
 import pytest
+from pytest_mock import MockerFixture
 
 
 @pytest.fixture
-def mock_build(mocker):
+def mock_build(mocker: MockerFixture) -> MagicMock:
     mocker.patch(
         "pyproject_installer.lib.build_backend.os.pipe",
         return_value=(3, 4),

--- a/tests/unit/test_build/test_backend_caller.py
+++ b/tests/unit/test_build/test_backend_caller.py
@@ -387,6 +387,24 @@ def test_in_tree_backend_not_used(build_backend, build_backend_path):
         )
 
 
+def test_in_tree_backend_namespace_package(
+    in_tree_build_backend,
+    build_backend_path,
+):
+    """A namespace package (directory without __init__.py) has __file__ = None,
+    so backend_object must reject it when backend-path enforcement is requested.
+    """
+    be = in_tree_build_backend("ns_be")
+    (be / "__init__.py").unlink()  # turn the package into a namespace package
+    with pytest.raises(
+        ValueError,
+        match="Backend 'ns_be' has no __file__ location",
+    ):
+        backend_caller.main(
+            [be.name, "build_wheel", "--backend-path", build_backend_path],
+        )
+
+
 @pytest.mark.parametrize("hook", ("build_wheel", "build_sdist"))
 def test_missing_mandatory_hook(hook, build_backend):
     hooks = list(backend_caller.SUPPORTED_HOOKS)

--- a/tests/unit/test_deps/conftest.py
+++ b/tests/unit/test_deps/conftest.py
@@ -1,19 +1,25 @@
+from collections.abc import Callable
+from pathlib import Path
+
 import pytest
 
 
 @pytest.fixture
-def depsconfig_path(tmpdir, monkeypatch):
+def depsconfig_path(
+    tmpdir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Path:
     depsconfig_path = tmpdir / "foo.json"
     monkeypatch.chdir(tmpdir)
     return depsconfig_path
 
 
 @pytest.fixture
-def depsconfig(depsconfig_path):
+def depsconfig(depsconfig_path: Path) -> Callable[..., Path]:
     """Create deps config"""
     default_content = '{"sources": {"foo": {"srctype": "metadata"}}}'
 
-    def _gen_depsconfig(content=default_content):
+    def _gen_depsconfig(content: str = default_content) -> Path:
         depsconfig_path.write_text(content, encoding="utf-8")
         return depsconfig_path
 

--- a/tests/unit/test_deps/test_collectors/conftest.py
+++ b/tests/unit/test_deps/test_collectors/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 
-VALID_PEP508_DEPS_DATA = (
+VALID_PEP508_DEPS_DATA: tuple[tuple[list[str], list[str]], ...] = (
     ([], []),
     (["foo"], ["foo"]),
     (["foo == 1.0"], ["foo==1.0"]),
@@ -21,7 +21,7 @@ VALID_PEP508_DEPS_DATA = (
     ),
 )
 
-INVALID_PEP508_DEPS_DATA = (
+INVALID_PEP508_DEPS_DATA: tuple[tuple[list[str], list[str]], ...] = (
     (["_foo"], []),
     (["foo", "bar !> 1.0"], ["foo"]),
     (["foo", "bar > 1.0; invalid_marker=='1.0'"], ["foo"]),
@@ -30,21 +30,27 @@ INVALID_PEP508_DEPS_DATA = (
 
 
 @pytest.fixture(params=VALID_PEP508_DEPS_DATA)
-def valid_pep508_data(request):
+def valid_pep508_data(
+    request: pytest.FixtureRequest,
+) -> tuple[list[str], list[str]]:
     """
     return tuple of two elements,
     first item of them is actual valid PEP508 data (supposed to be collected),
     the second one is data expected to be read from deps config after `sync`.
     """
-    return request.param
+    result: tuple[list[str], list[str]] = request.param
+    return result
 
 
 @pytest.fixture(params=INVALID_PEP508_DEPS_DATA)
-def invalid_pep508_data(request):
+def invalid_pep508_data(
+    request: pytest.FixtureRequest,
+) -> tuple[list[str], list[str]]:
     """
     return tuple of two elements,
     first item of them is actual invalid PEP508 data (supposed to be collected),
     the second one is data expected to be read from deps config after `sync` if
     invalid dependency specifiers are allowed by a collector.
     """
-    return request.param
+    result: tuple[list[str], list[str]] = request.param
+    return result

--- a/tests/unit/test_deps/test_collectors/test_pep518.py
+++ b/tests/unit/test_deps/test_collectors/test_pep518.py
@@ -2,6 +2,7 @@ import json
 import re
 import textwrap
 from copy import deepcopy
+from typing import Any
 
 import pytest
 
@@ -36,7 +37,7 @@ def test_pep518_collector_missing_pyproject_toml(
     # prepare source config
     srcname = "foo"
     collector = "pep518"
-    input_conf = {"sources": {srcname: {"srctype": collector}}}
+    input_conf: dict[str, Any] = {"sources": {srcname: {"srctype": collector}}}
     depsconfig_path = depsconfig(json.dumps(input_conf))
 
     monkeypatch.chdir(tmpdir)
@@ -59,7 +60,7 @@ def test_pep518_collector_missing_build_system(
     # prepare source config
     srcname = "foo"
     collector = "pep518"
-    input_conf = {"sources": {srcname: {"srctype": collector}}}
+    input_conf: dict[str, Any] = {"sources": {srcname: {"srctype": collector}}}
     depsconfig_path = depsconfig(json.dumps(input_conf))
 
     pyproject_path = pyproject("")

--- a/tests/unit/test_deps/test_collectors/test_pep735.py
+++ b/tests/unit/test_deps/test_collectors/test_pep735.py
@@ -29,7 +29,9 @@ else:
             self._expected_types = expected_types
             self._match = match
             self._cm = pytest.raises(errors.ExceptionGroup)
-            self._info = None
+            self._info: pytest.ExceptionInfo[errors.ExceptionGroup] | None = (
+                None
+            )
 
         def __enter__(self):
             self._info = self._cm.__enter__()
@@ -37,6 +39,7 @@ else:
 
         def __exit__(self, exc_type, exc_val, exc_tb):
             handled = self._cm.__exit__(exc_type, exc_val, exc_tb)
+            assert self._info is not None
             eg = self._info.value
             if self._match is not None:
                 matched = re.search(self._match, eg.message)

--- a/tests/unit/test_deps/test_deps_config.py
+++ b/tests/unit/test_deps/test_deps_config.py
@@ -1,6 +1,7 @@
 import json
 import re
 from copy import deepcopy
+from typing import Any
 
 import pytest
 
@@ -232,7 +233,7 @@ def test_config_delete(depsconfig):
 
     deps_command(action, depsconfig_path, srcname=srcname)
     config_data = json.loads(depsconfig_path.read_text(encoding="utf-8"))
-    expected_data = {"sources": {}}
+    expected_data: dict[str, Any] = {"sources": {}}
     assert config_data == expected_data
 
 
@@ -277,7 +278,7 @@ def test_config_show(select_data, depsconfig, capsys):
 
     deps_command(action, depsconfig_path, srcnames=select)
 
-    out_conf = {"sources": {}}
+    out_conf: dict[str, Any] = {"sources": {}}
     for srcname in selected:
         out_conf["sources"][srcname] = input_conf["sources"][srcname]
     expected_out = json.dumps(out_conf, indent=2) + "\n"
@@ -317,12 +318,12 @@ def test_config_show_empty(depsconfig, capsys):
     action = "show"
 
     # prepare source config
-    input_conf = {"sources": {}}
+    input_conf: dict[str, Any] = {"sources": {}}
     depsconfig_path = depsconfig(json.dumps(input_conf))
 
     deps_command(action, depsconfig_path, srcnames=[])
 
-    output_conf = {"sources": {}}
+    output_conf: dict[str, Any] = {"sources": {}}
     expected_out = json.dumps(output_conf, indent=2) + "\n"
 
     captured = capsys.readouterr()
@@ -336,7 +337,7 @@ def test_config_sync_empty(depsconfig, capsys):
     action = "sync"
 
     # prepare source config
-    input_conf = {"sources": {}}
+    input_conf: dict[str, Any] = {"sources": {}}
     depsconfig_path = depsconfig(json.dumps(input_conf))
 
     deps_command(action, depsconfig_path, srcnames=[])
@@ -366,7 +367,7 @@ def test_config_sync_selected(select_data, depsconfig, mock_collector, capsys):
     select, synced = select_data
 
     # prepare source config
-    input_conf = {
+    input_conf: dict[str, Any] = {
         "sources": {
             "foo": {"srctype": "mock_collector"},
             "bar": {"srctype": "mock_collector"},
@@ -746,7 +747,7 @@ def test_config_eval_empty(depsconfig, capsys):
     action = "eval"
 
     # prepare source config
-    input_conf = {"sources": {}}
+    input_conf: dict[str, Any] = {"sources": {}}
     depsconfig_path = depsconfig(json.dumps(input_conf))
 
     deps_command(action, depsconfig_path, srcnames=[])

--- a/tests/unit/test_install/test_installer.py
+++ b/tests/unit/test_install/test_installer.py
@@ -18,6 +18,7 @@ from pyproject_installer.install_cmd._install import (
     get_installation_scheme,
 )
 from pyproject_installer.lib.scripts import SCRIPT_TEMPLATE
+from pyproject_installer.lib.wheel import WheelFile
 
 
 def expected_pyc_lines(path):
@@ -122,6 +123,18 @@ def test_bad_wheel(tmpdir, destdir):
         match=f"Error reading wheel {bad_whl}: ",
     ):
         install_wheel(bad_whl, destdir=destdir)
+
+
+def test_extract_raises_when_zipfile_uninitialized(
+    wheel,
+    wheel_contents,
+    tmpdir,
+):
+    """WheelFile.extract rejects use when _zipfile ended up unset."""
+    wf = WheelFile(wheel(contents=wheel_contents()))
+    wf._zipfile = None  # noqa: SLF001  # simulate post-init corruption
+    with pytest.raises(WheelFileError, match="Wheel was not initialized"):
+        wf.extract(tmpdir / "extract_target")
 
 
 @pytest.mark.skipif(

--- a/tests/unit/test_install/test_installer.py
+++ b/tests/unit/test_install/test_installer.py
@@ -137,6 +137,27 @@ def test_extract_raises_when_zipfile_uninitialized(
         wf.extract(tmpdir / "extract_target")
 
 
+def test_extract_default_members_uses_memberlist(
+    wheel,
+    wheel_contents,
+    installed_wheel,
+):
+    """extract() without a members argument extracts the full memberlist."""
+    dest_wheel = installed_wheel()
+    wf = WheelFile(wheel(contents=wheel_contents()))
+    wf.extract(dest_wheel.destdir)  # no members= -> default-members branch
+    expected_filelist = {
+        dest_wheel.destdir / f
+        for f in (
+            "foo/__init__.py",
+            "foo-1.0.dist-info/METADATA",
+            "foo-1.0.dist-info/WHEEL",
+            "foo-1.0.dist-info/RECORD",
+        )
+    }
+    assert dest_wheel.filelist() == expected_filelist
+
+
 @pytest.mark.skipif(
     # pylint: disable-next=use-implicit-booleaness-not-comparison-to-zero
     os.geteuid() == 0,

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -3,6 +3,7 @@ import subprocess
 import sys
 import textwrap
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -56,7 +57,7 @@ def preserve_cwd(monkeypatch):
 @pytest.fixture
 def record_cwd():
     """Patch a mocked command to record its cwd"""
-    command_cwd = []
+    command_cwd: list[Path] = []
 
     def _patch_mocked_cmd(mocked_cmd):
         def _record_cwd():
@@ -744,7 +745,7 @@ def test_deps_cli_show_default(mock_deps_command):
     deps_args = ["deps", action]
 
     r_args = (action, Path(depsconfig))
-    r_kwargs = {"srcnames": []}
+    r_kwargs: dict[str, Any] = {"srcnames": []}
 
     project_main.main(deps_args)
     mock_deps_command.assert_called_once_with(*r_args, **r_kwargs)
@@ -761,7 +762,7 @@ def test_deps_cli_show_depsconfig(mock_deps_command):
     deps_args = ["deps", "--depsconfig", depsconfig, action]
 
     r_args = (action, Path(depsconfig))
-    r_kwargs = {"srcnames": []}
+    r_kwargs: dict[str, Any] = {"srcnames": []}
 
     project_main.main(deps_args)
     mock_deps_command.assert_called_once_with(*r_args, **r_kwargs)
@@ -1285,7 +1286,7 @@ def test_deps_cli_eval_default(mock_deps_command):
     deps_args = ["deps", action]
 
     r_args = (action, Path(depsconfig))
-    r_kwargs = {
+    r_kwargs: dict[str, Any] = {
         "srcnames": [],
         "depformat": None,
         "depformatextra": None,
@@ -1308,7 +1309,7 @@ def test_deps_cli_eval_depsconfig(mock_deps_command):
     deps_args = ["deps", "--depsconfig", depsconfig, action]
 
     r_args = (action, Path(depsconfig))
-    r_kwargs = {
+    r_kwargs: dict[str, Any] = {
         "srcnames": [],
         "depformat": None,
         "depformatextra": None,
@@ -1356,7 +1357,7 @@ def test_deps_cli_eval_depformat(mock_deps_command):
     deps_args = ["deps", action, "--depformat", "$name"]
 
     r_args = (action, Path(depsconfig))
-    r_kwargs = {
+    r_kwargs: dict[str, Any] = {
         "srcnames": [],
         "depformat": "$name",
         "depformatextra": None,
@@ -1386,7 +1387,7 @@ def test_deps_cli_eval_depformat_depformatextra(mock_deps_command):
     ]
 
     r_args = (action, Path(depsconfig))
-    r_kwargs = {
+    r_kwargs: dict[str, Any] = {
         "srcnames": [],
         "depformat": "$name$fextra",
         "depformatextra": "+$extra",
@@ -1431,7 +1432,7 @@ def test_deps_cli_eval_extra(mock_deps_command):
     deps_args = ["deps", action, "--extra", extra]
 
     r_args = (action, Path(depsconfig))
-    r_kwargs = {
+    r_kwargs: dict[str, Any] = {
         "srcnames": [],
         "depformat": None,
         "depformatextra": None,

--- a/tests/unit/test_run/test_env.py
+++ b/tests/unit/test_run/test_env.py
@@ -651,3 +651,20 @@ def test_env_content_console_script(wheel_cscript, mock_usps, mock_ssps):
             main="main",
         )
         assert expected_content == json_data["content"][name]
+
+
+def test_venv_environ_raises_when_context_uninitialized(tmpdir):
+    """venv_environ() must reject use before create() populates context."""
+    venv = _run_env.PyprojectVenv(tmpdir / "wheel.whl")
+    with pytest.raises(ValueError, match="Uninitialized context"):
+        venv.venv_environ()
+
+
+def test_create_raises_when_super_leaves_context_unset(tmpdir, mocker):
+    """create() must surface a context that wasn't populated by the parent."""
+    venv = _run_env.PyprojectVenv(tmpdir / "wheel.whl")
+    # Skip real venv creation so ensure_directories never runs and self.context
+    # stays None.
+    mocker.patch("venv.EnvBuilder.create")
+    with pytest.raises(ValueError, match="Uninitialized context"):
+        venv.create(tmpdir / "venv_dir")

--- a/tests/unit/test_run/test_env.py
+++ b/tests/unit/test_run/test_env.py
@@ -637,7 +637,9 @@ def test_env_content_console_script(wheel_cscript, mock_usps, mock_ssps):
     expected_shebang = build_shebang(
         str(
             Path(json_data["bin_dir"])
-            / Path(sys._base_executable).name,  # noqa: SLF001
+            # sys._base_executable is a documented runtime attribute; not in
+            # typeshed.
+            / Path(sys._base_executable).name,  # type: ignore[attr-defined]  # noqa: SLF001
         ),
     )
     # build_shebang is covered by installer's tests


### PR DESCRIPTION
- type annotations across src/, backend/, tests/
- enable mypy strict; drop allowlist (whole tree type-checks)
- mark package as PEP 561 typed (py.typed)
- ci: mypy step with pretty-output flags
    
Fixes: https://github.com/stanislavlevin/pyproject_installer/issues/149

## Summary by Sourcery

Add comprehensive type annotations across core library, backend, CLI, dependency collection, and tests, and enforce strict static typing in development and CI.

Enhancements:
- Introduce precise TypedDicts, Protocols, Literals, and overloads for build backends, wheels, metadata parsing, dependency config, and collectors to improve type safety and clarity.
- Refine public and internal APIs (including CLI helpers, virtualenv management, RPM filelist generation, and installer logic) to use explicit, typed arguments and return values.
- Allow packaging of the PEP 561 typing marker (py.typed) in wheels and sdists so the library is recognized as typed by consumers.
- Tighten coverage configuration to require 100% coverage and extend linting guidance to include mypy in contributor docs.

Build:
- Mark the distribution as typed via classifiers and packaging metadata, and add strict mypy configuration to pyproject.toml for the source tree.
- Wire mypy into the CI pipeline with pretty error reporting flags alongside existing linting steps.

Tests:
- Extend and adjust unit and integration tests to cover new typed behaviors, error paths, and helper utilities (e.g., wheel extraction safety, venv context handling, backend-path enforcement).