### PR TITLE
feat(install): add --exclude-paths install option

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,32 @@ python -m pyproject_installer install
 > /usr/share/foo/asset.dat
 > ```
 
+> **`--exclude-paths PATTERN [PATTERN ...]`**
+>
+> One or more `fnmatch` glob patterns. Files whose wheel-relative POSIX path matches any pattern are excluded from installation. Pattern syntax follows Python's [`fnmatch`](https://docs.python.org/3/library/fnmatch.html) module: `*` matches any run of characters including `/`; `?` matches one character; `[seq]` / `[!seq]` are character classes.
+>
+> *Path format:* patterns are matched against the wheel's ZIP `namelist()` entries verbatim. Those entries are always forward-slash separated POSIX paths with no leading `/` and no `./` prefix, regardless of host operating system. Examples of what a pattern matches against: `pkg/__init__.py`, `pkg/sub/foo.py`, `pkg-1.0.dist-info/METADATA`, `pkg-1.0.data/scripts/cli`.
+>
+> Intended for RPM packaging: strip test files (`tests/`, `test_*.py`, `*_test.py`) and other artifacts the upstream project shipped inside the wheel but that aren't useful in installed form.
+>
+> Because `*` is slash-blind in `fnmatch`, every pattern should include literal `/` anchors to avoid leaking across directory boundaries. Typical default list (root-anchored + nested forms, suitable for an RPM macro):
+>
+> ```
+> tests/*       */tests/*
+> test_*.py     */test_*.py
+> *_test.py     */*_test.py
+> ```
+>
+> No hard-coded exceptions: a pattern matching `*.dist-info/METADATA` does strip it. System-level filtering of `dist-info` content remains controlled by `--no-strip-dist-info`.
+>
+> *Scope -- wheel members only.* Patterns are matched against the wheel's ZIP namelist before extraction. Content synthesised by the installer downstream is **not** subject to these patterns: console-script wrappers generated from `entry_points.txt`, the `INSTALLER` file written by `--installer`, and `.pyc` files produced post-install by external bytecompile steps (e.g. RPM's `brp-python-bytecompile`). To suppress generated console scripts, exclude `*.dist-info/entry_points.txt` -- the script-generation step is skipped when the file is absent from the install tree.
+>
+> *Default:* `[]`, no paths excluded.
+>
+> *Example:* `python -m pyproject_installer install --destdir /tmp/buildroot --exclude-paths 'tests/*' '*/tests/*' 'test_*.py' '*/test_*.py' '*_test.py' '*/*_test.py'`
+>
+> *Note:* `--exclude-paths` uses `nargs="+"` and greedily consumes positional-looking arguments. Place the wheel positional before `--exclude-paths`, terminate the option with `--`, or follow it with another flag -- otherwise the wheel argument is consumed as another pattern.
+
 > **`--platlib`**
 >
 > Force the install to land in the `platlib` site-packages directory regardless of the wheel's `Root-Is-Purelib` flag. Both the unprefixed wheel root and any `.data/purelib/` content are redirected to `platlib`. Mutually exclusive with `--purelib`.

--- a/docs/designs/exclude_paths_option.md
+++ b/docs/designs/exclude_paths_option.md
@@ -1,0 +1,160 @@
+## Abstract
+This RFE proposes a new opt-in install option `--exclude-paths
+<PATTERN> [<PATTERN> ...]` that drops wheel members matching one or
+more `fnmatch` glob patterns before extraction. Intended for
+downstream packagers - primarily RPM - who want to strip test files
+and other artifacts the upstream project shipped inside the wheel
+but that aren't useful in installed form.
+
+## Motivation
+Some Python projects ship test files (e.g. `pkg/tests/`,
+`test_*.py`, `*_test.py`) inside their wheel. For RPM packaging
+those files:
+
+- bloat the installed package without adding value to end users;
+- conflict with the distro convention that test code is not shipped
+  in runtime packages;
+- have to be removed today by a separate post-install rm/find step
+  in the spec, which duplicates the install-time knowledge of
+  wheel member paths and is fragile across project layouts.
+
+Letting the installer drop these files during extraction is the
+correct boundary: the installer already iterates over the wheel
+namelist and decides what to write to the destdir. Excluded
+members are simply never extracted, so no post-install cleanup
+runs and no empty parent directories are leaked.
+
+The option is opt-in because:
+
+- the default behaviour (byte-identical to today) is unchanged -
+  callers who don't pass `--exclude-paths` pay nothing;
+- not every consumer of the installer wants stripping - some need
+  the full wheel content for testing or development installs;
+- patterns are defined by the RPM macro on the consumer side; the
+  installer ships no hard-coded defaults.
+
+## Specification
+
+### User-facing contract
+- Syntax: `python -m pyproject_installer install --exclude-paths
+  <PATTERN> [<PATTERN> ...] [other install args...]`.
+- `--exclude-paths` is declared on the `install` subparser only.
+- `nargs="+"`: at least one pattern is required when the flag is
+  present. Default is an empty list - feature disabled.
+- Programmatic API: `install_wheel(..., exclude_paths=())` accepts
+  any `Sequence[str]`.
+
+### Pattern syntax
+Each `PATTERN` is an `fnmatch` glob (Python stdlib
+`fnmatch.fnmatchcase`):
+
+- `*` matches any run of characters including `/` (slash-blind).
+- `?` matches one character including `/`.
+- `[abc]`, `[!abc]` character classes.
+- The whole path must match the whole pattern.
+
+Because `*` is slash-blind, every pattern should include literal
+`/` anchors to avoid leaking across directory boundaries. A typical
+RPM-macro payload uses one root-anchored form and one nested form
+per abstract goal, e.g.:
+
+```
+tests/*       */tests/*
+test_*.py     */test_*.py
+*_test.py     */*_test.py
+```
+
+### Path format
+Patterns are matched against the wheel's ZIP `namelist()` entries
+verbatim. Per PEP 427 and the ZIP specification, those entries are
+always forward-slash separated POSIX paths with no leading `/` and
+no `./` prefix, regardless of host operating system. Concrete
+examples of what a pattern matches against: `pkg/foo.py`,
+`pkg/sub/foo.py`, `pkg-1.0.dist-info/METADATA`,
+`pkg-1.0.data/scripts/cli`. Directory-only zip entries (names
+ending in `/`) are dropped upstream by `WheelFile.memberlist` and
+never reach the matcher.
+
+### Behaviour
+A wheel member is excluded if its path matches any supplied
+pattern. Excluded members are never written to the destdir, so:
+
+- excluded files don't appear in the install tree;
+- parent directories that would have held only excluded files are
+  never created (`zipfile.ZipFile.extractall(members=...)` only
+  creates listed paths);
+- when combined with `--rpm-filelist`, excluded paths don't appear
+  in the generated filelist;
+- when `--exclude-paths` is absent, behaviour is byte-identical to
+  the current release.
+
+There are no hard-coded exceptions: a pattern that matches anything
+inside `dist-info` (or `.data`) strips it. System-level policy for
+`dist-info` content remains controlled by `--no-strip-dist-info`.
+
+### Scope: wheel members only
+Patterns apply to the wheel's namelist before extraction. Content
+synthesised downstream by the install pipeline is **not** subject
+to these patterns:
+
+- console-script wrappers generated from `entry_points.txt`;
+- the `INSTALLER` file written by `--installer`;
+- `.pyc` files produced post-install by external bytecompile steps
+  (e.g. RPM's `brp-python-bytecompile`).
+
+To suppress generated console scripts, exclude
+`*.dist-info/entry_points.txt`: the generator skips its work when
+the file is absent from the install tree.
+
+### Interaction with `filter_dist_info`
+`filter_dist_info` runs upstream of `filter_exclude_paths`. By
+default (`strip_dist_info=True`), only `METADATA` and
+`entry_points.txt` survive from `dist-info` and reach the exclude
+filter. With `--no-strip-dist-info`, every `dist-info` file reaches
+the exclude filter and is subject to user patterns.
+
+### argparse positional interaction
+`nargs="+"` is greedy: it consumes positional-looking tokens until
+it sees another flag, the `--` terminator, or end-of-argv. The
+wheel positional must therefore either precede `--exclude-paths`,
+be separated from the pattern list by `--`, or be preceded by
+another flag - otherwise the wheel argument is consumed as another
+pattern. This matches the existing constraint on `deps eval
+--exclude`.
+
+## Example
+
+```
+# Strip test artifacts at install time (typical RPM packaging use).
+python -m pyproject_installer install \
+    --destdir /tmp/buildroot \
+    --exclude-paths 'tests/*' '*/tests/*' \
+                    'test_*.py' '*/test_*.py' \
+                    '*_test.py' '*/*_test.py'
+```
+
+For RPM-macro consumption, the macro defines the pattern payload
+and forwards it:
+
+```rpm-spec
+%global pyproject_excluded_paths tests/* */tests/* test_*.py */test_*.py *_test.py */*_test.py
+
+%pyproject_install %{wheelpath} --exclude-paths %{pyproject_excluded_paths}
+```
+
+Given a wheel containing:
+
+- `pkg/__init__.py`
+- `pkg/core.py`
+- `pkg/tests/__init__.py`
+- `pkg/tests/test_core.py`
+- `pkg-1.0.dist-info/METADATA`
+
+After installing with the macro's patterns, the destdir contains
+only:
+
+- `pkg/__init__.py`
+- `pkg/core.py`
+- `pkg-1.0.dist-info/METADATA`
+
+The `pkg/tests/` directory is never created.

--- a/src/pyproject_installer/__main__.py
+++ b/src/pyproject_installer/__main__.py
@@ -62,6 +62,7 @@ def install(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
         strip_dist_info=args.strip_dist_info,
         rpm_filelist=args.rpm_filelist,
         force_site=args.force_site,
+        exclude_paths=args.exclude_paths,
     )
 
 
@@ -571,6 +572,18 @@ def main_parser(prog: str) -> MainArgumentParser:
             "write an RPM %%files-compatible filelist of installed "
             "files (plus computed .pyc paths) to PATH "
             "(default: None, filelist is not written)"
+        ),
+    )
+    parser_install.add_argument(
+        "--exclude-paths",
+        dest="exclude_paths",
+        nargs="+",
+        default=[],
+        metavar="PATTERN",
+        help=(
+            "fnmatch glob patterns. Files whose wheel-relative POSIX path "
+            "matches any pattern are excluded from installation. "
+            "(default: [])"
         ),
     )
     site_group = parser_install.add_mutually_exclusive_group()

--- a/src/pyproject_installer/install_cmd/_exclude_paths.py
+++ b/src/pyproject_installer/install_cmd/_exclude_paths.py
@@ -1,0 +1,40 @@
+"""Generator that filters wheel member paths via fnmatch glob patterns."""
+
+import fnmatch
+import logging
+from collections.abc import Iterable, Iterator, Sequence
+
+__all__ = ["filter_exclude_paths"]
+
+logger = logging.getLogger(__name__)
+
+
+def filter_exclude_paths(
+    members: Iterable[str],
+    *,
+    patterns: Sequence[str],
+) -> Iterator[str]:
+    """Yield members whose path matches no fnmatch pattern.
+
+    Patterns are matched against the wheel's ZIP ``namelist()`` entries
+    verbatim via ``fnmatch.fnmatchcase``. Those entries are always
+    forward-slash separated POSIX paths with no leading ``/`` and no
+    ``./`` prefix, regardless of host operating system (e.g.
+    ``pkg/foo.py``, ``pkg-1.0.dist-info/METADATA``).
+
+    Scope: wheel members only. Content synthesised downstream by the
+    install pipeline (console-script wrappers from ``entry_points.txt``,
+    ``INSTALLER`` written by ``--installer``, ``.pyc`` files produced
+    by an external bytecompile step) is not subject to these patterns.
+
+    No hard-coded exceptions: every member is subject to the supplied
+    patterns. System-level policy for dist-info contents lives upstream
+    in ``filter_dist_info``. An empty ``patterns`` is a no-op (every
+    member is yielded); ``install_wheel`` skips calling this function
+    entirely when ``exclude_paths`` is empty.
+    """
+    for m in members:
+        if any(fnmatch.fnmatchcase(m, p) for p in patterns):
+            logger.debug("Excluding %s", m)
+            continue
+        yield m

--- a/src/pyproject_installer/install_cmd/_install.py
+++ b/src/pyproject_installer/install_cmd/_install.py
@@ -2,11 +2,12 @@ import logging
 import shutil
 import sys
 import sysconfig
-from collections.abc import Callable, Iterable, Iterator
+from collections.abc import Callable, Iterable, Iterator, Sequence
 from importlib.metadata import PathDistribution
 from pathlib import Path
 from typing import Literal
 
+from pyproject_installer.install_cmd._exclude_paths import filter_exclude_paths
 from pyproject_installer.install_cmd._rpm_filelist import (
     write_rpm_filelist,
 )
@@ -178,6 +179,7 @@ def install_wheel(
     strip_dist_info: bool = True,
     rpm_filelist: Path | None = None,
     force_site: Literal["purelib", "platlib"] | None = None,
+    exclude_paths: Sequence[str] = (),
 ) -> None:
     wheel_path = validate_wheel_path(wheel_path)
     destdir = validate_destdir(destdir)
@@ -205,13 +207,14 @@ def install_wheel(
         logger.info("Wheel installation root: %s", rootdir)
 
         dist_info = f"{dist_name}-{dist_version}.dist-info"
-        members = tuple(
-            filter_dist_info(
-                dist_info,
-                members=whl.memberlist,
-                strip_dist_info=strip_dist_info,
-            ),
+        chain: Iterator[str] = filter_dist_info(
+            dist_info,
+            members=whl.memberlist,
+            strip_dist_info=strip_dist_info,
         )
+        if exclude_paths:
+            chain = filter_exclude_paths(chain, patterns=exclude_paths)
+        members = tuple(chain)
 
         installed_paths: set[Path] | None = (
             set() if rpm_filelist is not None else None

--- a/tests/unit/test_install/test_installer.py
+++ b/tests/unit/test_install/test_installer.py
@@ -98,7 +98,7 @@ def wheel_dir(tmpdir):
     def _wheel_dir(whl, dirname):
         with ZipFile(whl, "a") as z:
             if sys.version_info >= (3, 11):
-                # pylint: disable-next=no-member
+                # pylint: disable-next=no-member,useless-suppression
                 z.mkdir(dirname)
             else:
                 (dir_path := tmpdir / dirname).mkdir()
@@ -1316,3 +1316,165 @@ def test_force_site_invalid_value_rejected(
             destdir=destdir,
             force_site=bad_value,
         )
+
+
+def test_install_exclude_paths_default_empty(
+    wheel_contents,
+    wheel,
+    installed_wheel,
+):
+    """
+    Check install behavior is unchanged when exclude_paths is omitted.
+    Tests are not stripped.
+    """
+    contents = wheel_contents()
+    contents["foo/tests/__init__.py"] = ""
+    contents["foo/tests/test_x.py"] = ""
+    dest_wheel = installed_wheel()
+
+    install_wheel(wheel(contents=contents), destdir=dest_wheel.destdir)
+
+    expected_filelist = {
+        dest_wheel.sitedir / f
+        for f in (
+            "foo/__init__.py",
+            "foo/tests/__init__.py",
+            "foo/tests/test_x.py",
+            "foo-1.0.dist-info/METADATA",
+        )
+    }
+    assert dest_wheel.filelist() == expected_filelist
+
+
+def test_install_exclude_paths_drops_matching_members(
+    wheel_contents,
+    wheel,
+    installed_wheel,
+):
+    """
+    Check exclude_paths drops every matching wheel member.
+    """
+    contents = wheel_contents()
+    contents["foo/tests/__init__.py"] = ""
+    contents["foo/tests/test_x.py"] = ""
+    contents["foo/core.py"] = ""
+    dest_wheel = installed_wheel()
+
+    install_wheel(
+        wheel(contents=contents),
+        destdir=dest_wheel.destdir,
+        exclude_paths=["*/tests/*"],
+    )
+
+    expected_filelist = {
+        dest_wheel.sitedir / f
+        for f in (
+            "foo/__init__.py",
+            "foo/core.py",
+            "foo-1.0.dist-info/METADATA",
+        )
+    }
+    assert dest_wheel.filelist() == expected_filelist
+
+
+def test_install_exclude_paths_does_not_create_empty_parent_dirs(
+    wheel_contents,
+    wheel,
+    installed_wheel,
+):
+    """
+    Check the parent directory of an excluded member is not created
+    when the excluded file is the sole occupant of that directory.
+    zipfile.ZipFile.extractall(members=...) only creates listed
+    paths, so a directory that would have held only the excluded
+    file is never instantiated in the destdir.
+    """
+    contents = wheel_contents()
+    contents["foo/tests/test_x.py"] = ""
+    dest_wheel = installed_wheel()
+
+    install_wheel(
+        wheel(contents=contents),
+        destdir=dest_wheel.destdir,
+        exclude_paths=["foo/tests/test_x.py"],
+    )
+
+    expected_filelist = {
+        dest_wheel.sitedir / f
+        for f in (
+            "foo/__init__.py",
+            "foo-1.0.dist-info/METADATA",
+        )
+    }
+    assert dest_wheel.filelist() == expected_filelist
+
+
+def test_install_exclude_paths_can_strip_dist_info_files(
+    wheel_contents,
+    wheel,
+    installed_wheel,
+):
+    """
+    Check a pattern targeting a dist-info file does strip it.
+    Excluding entry_points.txt is the canonical use: it suppresses
+    the generated console-script wrappers because the script
+    generator only runs when the file is present in the install
+    tree.
+    """
+    contents = wheel_contents()
+    contents["foo-1.0.dist-info/entry_points.txt"] = (
+        "[console_scripts]\nbar = foo:main\n"
+    )
+    dest_wheel = installed_wheel()
+
+    install_wheel(
+        wheel(contents=contents),
+        destdir=dest_wheel.destdir,
+        exclude_paths=["*.dist-info/entry_points.txt"],
+    )
+
+    expected_filelist = {
+        dest_wheel.sitedir / f
+        for f in (
+            "foo/__init__.py",
+            "foo-1.0.dist-info/METADATA",
+        )
+    }
+    assert dest_wheel.filelist() == expected_filelist
+
+
+def test_install_exclude_paths_with_rpm_filelist_omits_stripped(
+    wheel_contents,
+    wheel,
+    tmpdir,
+):
+    """
+    Check rpm_filelist contains only non-excluded entries.
+    """
+    contents = wheel_contents()
+    contents["foo/tests/__init__.py"] = ""
+    contents["foo/tests/test_x.py"] = ""
+    destdir = tmpdir / "destdir"
+    destdir.mkdir()
+    filelist = tmpdir / "foo.files"
+
+    install_wheel(
+        wheel(contents=contents),
+        destdir=destdir,
+        rpm_filelist=filelist,
+        exclude_paths=["*/tests/*"],
+    )
+
+    recorded_files = filelist.read_text(encoding="utf-8").splitlines()
+    purelib = get_installation_scheme("foo")["purelib"]
+    expected_files = sorted(
+        (
+            f"%dir {purelib}/foo",
+            f"{purelib}/foo/__init__.py",
+            f"%dir {purelib}/foo/__pycache__",
+            *expected_pyc_lines(f"{purelib}/foo/__init__.py"),
+            f"%dir {purelib}/foo-1.0.dist-info",
+            f"{purelib}/foo-1.0.dist-info/METADATA",
+        ),
+    )
+    assert recorded_files == expected_files

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -337,12 +337,13 @@ def test_install_cli_default(mock_install_wheel, mock_read_tracker):
     wheel = Path.cwd() / "dist" / "foo.whl"
     wheel_tracker = wheel.parent / project_main.WHEEL_TRACKER
     i_args = (wheel,)
-    i_kwargs = {
+    i_kwargs: dict[str, Any] = {
         "destdir": destdir,
         "installer": None,
         "strip_dist_info": True,
         "rpm_filelist": None,
         "force_site": None,
+        "exclude_paths": [],
     }
 
     project_main.main(install_args)
@@ -358,12 +359,13 @@ def test_install_cli_destdir(mock_install_wheel, mock_read_tracker):
     wheel = Path.cwd() / "dist" / "foo.whl"
     wheel_tracker = wheel.parent / project_main.WHEEL_TRACKER
     i_args = (wheel,)
-    i_kwargs = {
+    i_kwargs: dict[str, Any] = {
         "destdir": destdir,
         "installer": None,
         "strip_dist_info": True,
         "rpm_filelist": None,
         "force_site": None,
+        "exclude_paths": [],
     }
 
     project_main.main(install_args)
@@ -378,12 +380,13 @@ def test_install_cli_wheel(mock_install_wheel, mock_read_tracker):
 
     destdir = Path("/")
     i_args = (wheel,)
-    i_kwargs = {
+    i_kwargs: dict[str, Any] = {
         "destdir": destdir,
         "installer": None,
         "strip_dist_info": True,
         "rpm_filelist": None,
         "force_site": None,
+        "exclude_paths": [],
     }
 
     project_main.main(install_args)
@@ -398,12 +401,13 @@ def test_install_cli_wheel_destdir(mock_install_wheel, mock_read_tracker):
     install_args = ["install", str(wheel), "--destdir", str(destdir)]
 
     i_args = (wheel,)
-    i_kwargs = {
+    i_kwargs: dict[str, Any] = {
         "destdir": destdir,
         "installer": None,
         "strip_dist_info": True,
         "rpm_filelist": None,
         "force_site": None,
+        "exclude_paths": [],
     }
 
     project_main.main(install_args)
@@ -425,6 +429,7 @@ def test_install_cli_installer_tool(mock_install_wheel, mock_read_tracker):
         "strip_dist_info": True,
         "rpm_filelist": None,
         "force_site": None,
+        "exclude_paths": [],
     }
 
     project_main.main(install_args)
@@ -440,12 +445,13 @@ def test_install_cli_no_strip_dist_info(mock_install_wheel):
     destdir = Path("/")
     wheel = Path.cwd() / "dist" / "foo.whl"
     i_args = (wheel,)
-    i_kwargs = {
+    i_kwargs: dict[str, Any] = {
         "destdir": destdir,
         "installer": None,
         "strip_dist_info": False,
         "rpm_filelist": None,
         "force_site": None,
+        "exclude_paths": [],
     }
 
     project_main.main(install_args)
@@ -483,6 +489,7 @@ def test_install_cli_rpm_filelist(mock_install_wheel, tmpdir):
         "strip_dist_info": True,
         "rpm_filelist": filelist,
         "force_site": None,
+        "exclude_paths": [],
     }
 
     project_main.main(install_args)
@@ -499,12 +506,13 @@ def test_install_cli_platlib(mock_install_wheel):
     destdir = Path("/")
     wheel = Path.cwd() / "dist" / "foo.whl"
     i_args = (wheel,)
-    i_kwargs = {
+    i_kwargs: dict[str, Any] = {
         "destdir": destdir,
         "installer": None,
         "strip_dist_info": True,
         "rpm_filelist": None,
         "force_site": "platlib",
+        "exclude_paths": [],
     }
 
     project_main.main(install_args)
@@ -521,12 +529,13 @@ def test_install_cli_purelib(mock_install_wheel):
     destdir = Path("/")
     wheel = Path.cwd() / "dist" / "foo.whl"
     i_args = (wheel,)
-    i_kwargs = {
+    i_kwargs: dict[str, Any] = {
         "destdir": destdir,
         "installer": None,
         "strip_dist_info": True,
         "rpm_filelist": None,
         "force_site": "purelib",
+        "exclude_paths": [],
     }
 
     project_main.main(install_args)
@@ -549,6 +558,72 @@ def test_install_cli_platlib_purelib_mutually_exclusive(
     assert not captured.out
     # actual error message is controlled by cpython,
     # so it's unreliable to check captured.err
+    mock_install_wheel.assert_not_called()
+
+
+@pytest.mark.usefixtures("mock_read_tracker")
+def test_install_cli_exclude_paths_multiple(mock_install_wheel):
+    """
+    Run install with --exclude-paths passing multiple patterns.
+    """
+    install_args = [
+        "install",
+        "--exclude-paths",
+        "tests/*",
+        "*/tests/*",
+        "test_*.py",
+    ]
+
+    destdir = Path("/")
+    wheel = Path.cwd() / "dist" / "foo.whl"
+    i_args = (wheel,)
+    i_kwargs = {
+        "destdir": destdir,
+        "installer": None,
+        "strip_dist_info": True,
+        "rpm_filelist": None,
+        "force_site": None,
+        "exclude_paths": ["tests/*", "*/tests/*", "test_*.py"],
+    }
+
+    project_main.main(install_args)
+    mock_install_wheel.assert_called_once_with(*i_args, **i_kwargs)
+
+
+@pytest.mark.usefixtures("mock_read_tracker")
+def test_install_cli_exclude_paths_single(mock_install_wheel):
+    """
+    Run install with --exclude-paths passing a single pattern.
+    """
+    install_args = ["install", "--exclude-paths", "tests/*"]
+
+    destdir = Path("/")
+    wheel = Path.cwd() / "dist" / "foo.whl"
+    i_args = (wheel,)
+    i_kwargs = {
+        "destdir": destdir,
+        "installer": None,
+        "strip_dist_info": True,
+        "rpm_filelist": None,
+        "force_site": None,
+        "exclude_paths": ["tests/*"],
+    }
+
+    project_main.main(install_args)
+    mock_install_wheel.assert_called_once_with(*i_args, **i_kwargs)
+
+
+@pytest.mark.usefixtures("mock_read_tracker")
+def test_install_cli_exclude_paths_requires_value(mock_install_wheel):
+    """
+    --exclude-paths requires at least one value (nargs='+').
+    """
+    install_args = ["install", "--exclude-paths"]
+
+    with pytest.raises(SystemExit):
+        project_main.main(install_args)
+    # actual error message is controlled by cpython,
+    # so it's unreliable to check stderr
     mock_install_wheel.assert_not_called()
 
 


### PR DESCRIPTION
Opt-in `install --exclude-paths PATTERN [PATTERN ...]` that drops wheel members matching one or more fnmatch globs before extraction. Intended for RPM packaging to strip test files (pkg/tests/, test_*.py, *_test.py) and similar artifacts shipped inside wheels but unwanted in installed form. Default empty -- byte-identical when the flag isn't set. nargs="+", matching the existing `deps eval --exclude` convention.

See for details:
docs/designs/exclude_paths_option.md

Fixes: https://github.com/stanislavlevin/pyproject_installer/issues/151

## Summary by Sourcery

Add an opt-in install-time path exclusion mechanism to filter wheel contents based on glob patterns before extraction and document its behavior.

New Features:
- Introduce an --exclude-paths install CLI option that accepts one or more fnmatch glob patterns to omit matching wheel members from installation.
- Extend the install_wheel API with an exclude_paths parameter to support programmatic path-based exclusion of wheel contents.

Enhancements:
- Ensure excluded wheel members are never written to disk or RPM filelists, and their empty parent directories are not created.
- Document the design, usage, and packaging-oriented behavior of the exclude-paths option in a dedicated design document and README section.

Tests:
- Add install tests verifying default behavior without exclusions, correct dropping of matching members including dist-info files, absence of empty parent directories, and interaction with RPM filelists.
- Add CLI tests covering parsing and propagation of --exclude-paths for single and multiple patterns and enforcing that at least one pattern is provided.