### PR TITLE
feat(completion): add bash completion for pyproject-installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
     - [sync](#sync)
     - [eval](#eval)
     - [delete](#delete)
+  - [Bash completion](#bash-completion)
 - [Comparison with other tools](#comparison-with-other-tools)
 - [Bootstrap](#bootstrap)
 - [Tests](#tests)
@@ -556,6 +557,31 @@ Deconfigure source of Python dependencies.
 > *Example:* `python -m pyproject_installer deps delete build`
 
 See `python -m pyproject_installer deps delete --help` for full options.
+
+
+### Bash completion
+
+`pyproject-installer completion bash` writes a bash completion script to
+stdout. The script is generated from the live argparse tree and binds
+to the `pyproject-installer` console script.
+
+#### End-user one-shot install (no per-shell cost)
+
+```bash
+mkdir -p ~/.local/share/bash-completion/completions
+pyproject-installer completion bash \
+    > ~/.local/share/bash-completion/completions/pyproject-installer
+```
+
+The file is picked up lazily by `bash-completion` when the user first
+types `pyproject-installer<TAB>` in a new shell.
+
+#### End-user eval-on-startup (opt-in interpreter spawn per shell)
+
+```bash
+# in ~/.bashrc
+eval "$(pyproject-installer completion bash)"
+```
 
 
 ## Comparison with other tools

--- a/backend/metadata.py
+++ b/backend/metadata.py
@@ -53,6 +53,7 @@ Pep621MetadataType = TypedDict(
         "classifiers": list[str],
         "dynamic": list[str],
         "urls": dict[str, str],
+        "scripts": dict[str, str],
     },
     total=False,
 )
@@ -71,6 +72,7 @@ Pep621SupportedFieldsType = Literal[
     "classifiers",
     "dynamic",
     "urls",
+    "scripts",
 ]
 
 

--- a/backend/wheel.py
+++ b/backend/wheel.py
@@ -11,14 +11,15 @@ build_wheel:
    - exclude __pycache__ and .pyc
 """
 
+import configparser
 import csv
 import hashlib
 import logging
 import os
 import time
 from base64 import urlsafe_b64encode
-from collections.abc import Iterable
-from io import BytesIO, TextIOWrapper
+from collections.abc import Iterable, Mapping
+from io import BytesIO, StringIO, TextIOWrapper
 from pathlib import Path
 from types import TracebackType
 from typing import IO, Any
@@ -143,6 +144,34 @@ class WheelBuilder:
                 source_date_time_zinfo(time.time()),
             )
 
+    def package_entry_points(self, scripts: Mapping[str, str]) -> None:
+        """
+        Emit dist-info/entry_points.txt for [console_scripts].
+
+        See for details:
+        https://packaging.python.org/en/latest/specifications/entry-points/
+        """
+
+        # entry-point names are case-sensitive; default optionxform lowercases.
+        class CaseSensitiveConfigParser(configparser.ConfigParser):
+            def optionxform(self, optionstr: str) -> str:
+                return optionstr
+
+        cp = CaseSensitiveConfigParser(interpolation=None)
+        cp["console_scripts"] = {
+            name: scripts[name] for name in sorted(scripts)
+        }
+
+        buf = StringIO()
+        cp.write(buf)
+
+        with BytesIO(buf.getvalue().encode("utf-8")) as src:
+            self.package_file(
+                src,
+                str(Path(self.dist_info) / "entry_points.txt"),
+                source_date_time_zinfo(time.time()),
+            )
+
     def package_license_files(
         self,
         cwd: Path,
@@ -241,6 +270,8 @@ def build_wheel(
         whl.package_wheel_metadata()
         whl.package_metadata(CoreMetadata(metadata_pep621).dump_as_bytes())
         whl.package_license_files(cwd, backend_config["license_files"])
+        if scripts := metadata_pep621.get("scripts"):
+            whl.package_entry_points(scripts)
         whl.package_record()
 
     return whl.filename

--- a/docs/designs/bash_completion.md
+++ b/docs/designs/bash_completion.md
@@ -1,0 +1,371 @@
+## Abstract
+This RFE proposes a `completion` subcommand that emits a small bash
+wrapper. The wrapper sets `COMP_WORDS`, `COMP_CWORD`, and a sentinel
+env var, then re-invokes the binary at TAB time; the binary detects
+the sentinel and routes to an in-Python autocomplete handler that
+walks the argparse tree, computes candidates from the current cursor
+context, prints them one per line, and exits. Bash captures stdout
+into `COMPREPLY`. Inspired by pip's design.
+
+As prerequisites the project also gains a `pyproject-installer`
+console-script entry (so bash has a binary name to bind completion
+to) and the self-hosted backend learns to emit
+`dist-info/entry_points.txt` from PEP 621 `[project.scripts]`.
+
+No completion artefact is checked into the repository, no completion
+file is shipped inside the wheel, no `tools/`-side generator or CI
+drift gate is required, and the wrapper has no per-CLI knowledge so
+it cannot drift even in principle: the wrapper is invariant in
+`parser.prog` only, and the binary's live argparse tree is the
+single source of truth for every TAB press.
+
+## Motivation
+Interactive users of `pyproject-installer` benefit from tab completion
+of subcommands, option names, finite-choice option values (e.g.
+`deps add ... <srctype>`) and path arguments. The dominant deployment target -
+RPM packaging - already has an idiomatic place for completion files
+(`%{_datadir}/bash-completion/completions/<name>`); a `completion`
+subcommand lets the spec generate that file at package build time
+without forcing the upstream wheel to ship a static artefact.
+
+A static checked-in completion file would have required:
+
+- a `tools/`-side generator and a CI drift gate (regenerate, diff,
+  fail-on-diff) - because the file and the parser would be in two
+  places that must be kept synchronised;
+- a decision about whether to ship the file inside the wheel, which
+  in turn would require the self-hosted backend to learn `.data/data/`
+  routing.
+
+Routing TAB presses back through the binary removes both problems by
+construction. The wrapper has no per-CLI specifics (only `parser.prog`
+appears in it), and every TAB press reads the live argparse tree, so
+the script and the CLI it completes are always the same object walked
+the same way.
+
+The runtime cost is one Python interpreter spawn per TAB press,
+typically 50-100 ms on a warm system. This is on the upper end of
+what feels instantaneous, but bash users are familiar with similar
+latency from other completion implementations (pip, gh, kubectl).
+
+## Specification
+
+### User-facing contract
+- Syntax: `pyproject-installer completion bash`. Equivalent to
+  `python -m pyproject_installer completion bash`.
+- The subcommand takes exactly one positional, the shell name. Only
+  `bash` is recognised today; other values produce the standard
+  argparse error path (usage line on stderr, exit code
+  `ExitCodes.WRONG_USAGE`). The positional is declared with
+  `choices=SUPPORTED_SHELLS` to make the supported set discoverable
+  via `--help` and trivially extensible later (`zsh`, `fish`, ...).
+- Output is written to stdout: the bash wrapper, ~7 lines. No other
+  side effects: nothing is read from disk, no environment variables
+  are consulted, the working directory is not changed.
+- Exit code: `ExitCodes.OK` on success.
+- Output is deterministic for a fixed `parser.prog`: byte-identical
+  across runs.
+
+### Generated wrapper
+
+The complete output for `parser.prog = "pyproject-installer"`:
+
+```bash
+_pyproject_installer()
+{
+    local IFS=$' \t\n'
+    COMPREPLY=( $( COMP_WORDS="${COMP_WORDS[*]}" \
+                   COMP_CWORD=$COMP_CWORD \
+                   _PYPROJECT_INSTALLER_COMPLETE=1 "$1" 2>/dev/null ) )
+}
+complete -o nosort -F _pyproject_installer pyproject-installer
+```
+
+- `$1` is bash's standard convention for the command name passed to
+  the completion function. The wrapper re-executes that binary.
+- `_PYPROJECT_INSTALLER_COMPLETE=1` is the sentinel that switches
+  `cli_entry` into autocomplete mode (see below). The leading
+  underscore signals "internal protocol; do not set manually."
+- `stderr` is suppressed so partial errors from the autocomplete
+  handler never leak into the user's terminal mid-TAB.
+- `-o nosort` preserves the order in which the handler emits
+  candidates, so subcommands display before option names rather than
+  getting interleaved by bash's default lexicographic sort.
+- The wrapper is invariant in the argparse tree's shape; only
+  `parser.prog` is consulted (to name the bash function and the
+  `complete -o nosort -F` target).
+
+### Runtime dispatch
+
+`cli_entry` (the console-script entry) checks for the sentinel before
+normal argparse processing:
+
+```python
+def cli_entry() -> None:
+    if os.environ.get("_PYPROJECT_INSTALLER_COMPLETE") == "1":
+        from .completion_cmd._autocomplete import run_autocomplete
+        run_autocomplete(main_parser("pyproject-installer"))
+    main(sys.argv[1:], prog="pyproject-installer")
+```
+
+When the sentinel is set, `run_autocomplete` reads `COMP_WORDS` and
+`COMP_CWORD` from the environment, calls `compute_candidates`, prints
+the candidates one per line to stdout, and exits with code 0
+(or 1 if the env vars are missing/malformed).
+
+`compute_candidates(parser, words, cword) -> list[str]` is a pure
+function: given the words list and cursor index, it returns the
+filtered candidates. The dispatch tree:
+
+1. **Value-option context** - `prev` (word right before the cursor) is
+   a value-taking option on the active parser: offer that option's
+   value candidates. `--outdir <TAB>` (metavar=DIR) lists directories;
+   `--srctype <TAB>` (choices=) lists the choices; `--installer <TAB>`
+   (no path metavar, no choices) offers nothing.
+2. **Option-name context** - `cur` (word under the cursor) starts with
+   `-`: offer option names from the active parser, with
+   mutually-exclusive group siblings suppressed.
+3. **Subcommand context** - the active parser has subparsers: offer
+   subcommand names + the parser's own option names (so
+   `pyproject-installer <TAB>` shows `build install run deps
+   completion --help -v ...`).
+4. **Positional context** - the active parser has no subparsers:
+   count which positional slot the cursor is on (skipping option tokens
+   and values consumed by value-taking options) and offer that slot's
+   completion. A slot with `choices=` offers those choices; a slot
+   with a path-flavored `metavar` (`DIR`/`FILE`/`PATH`) offers paths.
+   Variadic positionals (`nargs in ("*", "+")`) absorb every slot from
+   their declaration onward. When no positional has anything to offer
+   (no positionals at all, a positional with neither `choices=` nor a
+   path metavar, or a slot past the fixed ones with no variadic), fall
+   back to the parser's own option names so the user sees something
+   actionable instead of an empty completion.
+
+The "active parser" is reached by walking the subparser tree from
+the top, consuming any token that names a subparser registered on the
+current parser. So `deps add NAME <TAB>` walks to the `add` parser
+(via `deps`), sees `["NAME"]` as its `parser_argv`, and
+recognises that the cursor is at positional slot 1 (`srctype`).
+
+### Value candidates
+
+`_value_candidates(action, current_word)` picks the candidates for an
+argument's value with a small priority chain:
+
+1. `action.choices` set -> offer the choices (sorted).
+2. Else look at `action.metavar`, case-insensitively:
+   - `DIR` -> directories only;
+   - `FILE` / `PATH` -> directories AND regular files;
+   - anything else (or no metavar) -> no candidates. Opaque strings
+     (`--installer NAME`, `--backend-config-settings JSON`, regex
+     lists, ...) deliberately offer nothing rather than a misleading
+     filename fallback.
+
+Path completion is therefore driven entirely by `metavar`. To enable
+directory or file completion for a new option, declare
+`metavar="DIR"` or `metavar="FILE"` on its `add_argument` call. The
+test `tests/unit/test_completion/test_path_metavars.py` walks the
+live parser and fails CI if a `type=Path` action is added without a
+path-flavored metavar, so the contract between the CLI shape and the
+completion engine cannot silently drift.
+
+Actions with no value to complete (`store_true/false/const`, `count`,
+`--help`, `--version`) never reach this function: they're filtered out
+of the value-taking option set by `_value_taking_options` via
+`action.nargs != 0`.
+
+### Terminating options (``--help`` / ``--version``)
+
+Before the four-way dispatch fires, `compute_candidates` checks
+whether any `_HelpAction` or `_VersionAction` option string already
+appears in *parser_argv*. If so it returns `[]` immediately:
+those actions call `parser.exit()` as soon as argparse parses them,
+so the binary will print help (or the version) and exit before the
+shell ever runs whatever the cursor word becomes. Matches git's and
+pip's behaviour: `pyproject-installer --help <TAB>` offers nothing.
+
+### Option-name filtering
+
+`_option_name_candidates` applies two suppression rules whenever
+option names are offered (branches 2, 3, and the branch-4 fallback
+all funnel through it):
+
+1. **Mutually-exclusive groups.** Argparse exposes group membership
+   via `parser._mutually_exclusive_groups`, each group carrying its
+   own `_group_actions`. If any member is already on the command
+   line, every member is dropped - siblings because argparse would
+   reject them, and the typed member itself because re-offering it
+   is misleading. So typing `install --platlib --<TAB>` offers
+   neither `--purelib` nor `--platlib`.
+2. **Non-repeatable options already typed.** Any option whose action
+   is *not* one of `append` / `append_const` / `count` / `extend` is
+   dropped from the candidate list once it (or any of its aliases)
+   appears on the line. So once `--help` is typed, neither `--help`
+   nor `-h` is offered again; a value option like `--depsconfig`
+   stops being suggested after its value is given; but a `count`
+   option like `-v` stays available so the user can stack `-v -v`.
+
+Both rules are generic: future mutually-exclusive groups and any
+new options anywhere in the CLI receive the same treatment with no
+code changes.
+
+### End-of-options sentinel (``--``)
+
+A bare `--` on the command line ends option parsing in argparse:
+every word after it is treated as a positional even if it looks
+option-shaped (e.g. `install -- --weird-filename.whl` fills the
+`wheel` positional with `--weird-filename.whl`). The dispatcher
+matches that semantic:
+
+- `_positional_candidates` flips an "after `--`" flag in its slot
+  counter, so words past the sentinel count as positionals regardless
+  of leading `-`.
+- Branches 1 and 2 (value-option context, option-name context) and
+  the branch-4 option-name fallback all suppress themselves when
+  `--` has already been committed on the line, because argparse
+  would reject further options. So `install -- foo.whl <TAB>`
+  returns no candidates: the wheel positional is filled, no more
+  positionals exist, and options are no longer accepted.
+
+A `--` typed as the cursor word itself (e.g. `install --<TAB>`) is
+not counted as committed - branch 2 still fires and offers option
+names. Only a `--` already in the COMP_WORDS prefix activates the
+suppression.
+
+### Path candidates
+
+`_path_candidates(current_word, *, dirs_only)` lists filesystem
+entries matching the cursor word as prefix via `pathlib.Path.glob`.
+Directories carry a trailing `/` so bash treats them as continuation
+points (cursor stays on the same word). When `dirs_only=True`
+(metavar=DIR) regular files are filtered out so the user only sees
+directories; when `dirs_only=False` (metavar=FILE/PATH) both are
+offered. An unreadable parent directory returns an empty list rather
+than crashing the TAB press.
+
+### Console-script entry
+A `[project.scripts]` table in `pyproject.toml`:
+
+```toml
+[project.scripts]
+pyproject-installer = "pyproject_installer.__main__:cli_entry"
+```
+
+`cli_entry()` is a wrapper added to `__main__.py` that either routes
+to `run_autocomplete` (when the sentinel env var is set) or falls
+through to the normal `main()` flow.
+
+The existing `python -m pyproject_installer` entry continues to work
+unchanged; both entries call `main()` with the same `cli_args` and
+differ only in the `prog` string surfaced in help output and in the
+generated completion wrapper's `complete -F ... <prog>` registration.
+
+### Backend prerequisite: `entry_points.txt`
+The self-hosted backend in `backend/` currently emits only the wheel
+members listed in `WheelBuilder.package_*` (modules, WHEEL, METADATA,
+license files, RECORD). It does not emit `dist-info/entry_points.txt`.
+Without that file the install pipeline's existing console-script
+generator (`src/pyproject_installer/install_cmd/_install.py:237`) has
+nothing to act on, so the `pyproject-installer` binary would not be
+created at install time.
+
+The backend's PEP 621 metadata parser already has access to
+`[project.scripts]` (it round-trips through core metadata as part of
+PEP 621 ingestion). The backend gains a single new method,
+`WheelBuilder.package_entry_points(scripts: Mapping[str, str])`, that
+emits the canonical `entry_points.txt` (INI-style `[console_scripts]`
+section) via `configparser` with `optionxform = str` to preserve
+entry-point name case.
+
+### Install variants
+Two documented ways to use the wrapper. Both feed from the same
+`pyproject-installer completion bash` output; they differ only in
+where that output lands.
+
+```bash
+# 1. End-user one-shot install. The bash-completion package picks it
+#    up lazily on the next new shell.
+mkdir -p ~/.local/share/bash-completion/completions
+pyproject-installer completion bash \
+    > ~/.local/share/bash-completion/completions/pyproject-installer
+
+# 2. End-user eval-on-startup.
+eval "$(pyproject-installer completion bash)"
+```
+
+The wrapper requires only the `complete` builtin and stderr
+redirection; no `bash-completion` package helpers are referenced.
+The actual TAB-time logic runs in Python and requires
+`pyproject-installer` to be reachable on the user's `PATH` - which
+it has to be for the user to invoke the tool anyway.
+
+### Module layout
+A package `src/pyproject_installer/completion_cmd/` mirrors the
+existing `build_cmd` / `install_cmd` / `run_cmd` / `deps_cmd` layout:
+
+```
+src/pyproject_installer/completion_cmd/
+    __init__.py        # SUPPORTED_SHELLS dispatch dict + completion_command
+    _bash.py           # wrapper template + emit()
+    _autocomplete.py   # runtime: introspection + compute_candidates + run_autocomplete
+```
+
+`SUPPORTED_SHELLS` in `__init__.py` is the single source of truth for
+which shells are supported (used both by argparse `choices=` and by
+the dispatcher).
+
+### Out of scope
+- Other shells (`zsh`, `fish`, `powershell`). The `choices=SUPPORTED_SHELLS`
+  positional reserves the dispatch surface; adding a shell is a
+  matter of writing a sibling `_zsh.py` and adding an entry to
+  `SUPPORTED_SHELLS`. The autocomplete runtime is shell-agnostic.
+- Dynamic completion that consults disk state beyond filesystem
+  paths (e.g. completing wheel filenames against
+  `dist/.wheeltracker`). The architecture supports this trivially
+  - it'd just be additional `_value_candidates` logic - but it's not
+  in scope for this RFE.
+- Shipping the wrapper inside the wheel. Wheel-side `.data/data/`
+  packaging is a separate concern, not required by this RFE.
+
+## Example
+
+```bash
+# Generate and install for the current user.
+mkdir -p ~/.local/share/bash-completion/completions
+pyproject-installer completion bash \
+    > ~/.local/share/bash-completion/completions/pyproject-installer
+
+# In a new shell:
+pyproject-installer <TAB><TAB>
+build  completion  deps  install  run
+
+pyproject-installer deps <TAB><TAB>
+add  delete  eval  show  sync
+
+pyproject-installer deps add mysrc <TAB><TAB>
+hatch  metadata  pdm  pep517  pep518  pep735  pip_reqfile  pipenv  poetry  tox
+
+pyproject-installer install --<TAB><TAB>
+--destdir              --installer            --no-strip-dist-info
+--exclude-paths        --platlib              --purelib
+--help                 --rpm-filelist
+
+pyproject-installer install --platlib --<TAB><TAB>
+--destdir              --installer            --no-strip-dist-info
+--exclude-paths        --platlib              --rpm-filelist
+                                              # --purelib suppressed
+```
+
+For RPM packaging:
+
+```rpm-spec
+%install
+...
+mkdir -p %{buildroot}%{_datadir}/bash-completion/completions
+%{python3} -m pyproject_installer completion bash \
+    > %{buildroot}%{_datadir}/bash-completion/completions/pyproject-installer
+
+%files
+...
+%{_datadir}/bash-completion/completions/pyproject-installer
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ dynamic = ["version"]
 source = "https://github.com/stanislavlevin/pyproject_installer"
 tracker = "https://github.com/stanislavlevin/pyproject_installer/issues"
 
+[project.scripts]
+pyproject-installer = "pyproject_installer.__main__:cli_entry"
+
 [build-system]
 requires = []
 build-backend = "backend"

--- a/src/pyproject_installer/__main__.py
+++ b/src/pyproject_installer/__main__.py
@@ -24,6 +24,8 @@ from typing import Any, NoReturn
 from . import __version__ as project_version
 from .build_cmd import WHEEL_TRACKER, build_sdist, build_wheel
 from .codes import ExitCodes
+from .completion_cmd import SUPPORTED_SHELLS, completion_command
+from .completion_cmd._autocomplete import run_autocomplete
 from .deps_cmd import DEFAULT_CONFIG_NAME, SUPPORTED_COLLECTORS, deps_command
 from .errors import DepsUnsyncedError, RunCommandEnvError, RunCommandError
 from .install_cmd import install_wheel
@@ -170,6 +172,13 @@ def run(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
 
     result.report()
     sys.exit(result.status)
+
+
+def completion(
+    args: argparse.Namespace,
+    parser: argparse.ArgumentParser,  # noqa: ARG001  (handler convention)
+) -> None:
+    completion_command(args.shell)
 
 
 def default_built_wheel() -> Path:
@@ -485,6 +494,7 @@ def main_parser(prog: str) -> MainArgumentParser:
         type=Path,
         nargs="?",
         default=None,
+        metavar="DIR",
         help=(
             "source directory "
             "(default: current working directory)%(default).0s"
@@ -494,6 +504,7 @@ def main_parser(prog: str) -> MainArgumentParser:
         "--outdir",
         "-o",
         type=Path,
+        metavar="DIR",
         help="output directory for built wheel (default: {srcdir}/dist)",
     )
     parser_build.add_argument(
@@ -528,6 +539,7 @@ def main_parser(prog: str) -> MainArgumentParser:
         type=Path,
         nargs="?",
         default=None,
+        metavar="FILE",
         help=(
             "wheel file to install "
             "(default: contructed as directory {cwd}/dist and wheel filename "
@@ -539,6 +551,7 @@ def main_parser(prog: str) -> MainArgumentParser:
         "-d",
         default="/",
         type=Path,
+        metavar="DIR",
         help=(
             "Wheel installation root will be prepended with destdir "
             "(default: /)"
@@ -624,6 +637,7 @@ def main_parser(prog: str) -> MainArgumentParser:
         "--wheel",
         type=Path,
         default=None,
+        metavar="FILE",
         help=(
             "wheel file to install "
             "(default: contructed as directory {cwd}/dist and wheel filename "
@@ -652,6 +666,7 @@ def main_parser(prog: str) -> MainArgumentParser:
         "--depsconfig",
         type=Path,
         default=None,
+        metavar="FILE",
         help=(
             "configuration file to use "
             f"(default: {{cwd}}/{DEFAULT_CONFIG_NAME})%(default).0s"
@@ -659,6 +674,22 @@ def main_parser(prog: str) -> MainArgumentParser:
     )
 
     deps_subparsers(parser_deps)
+
+    # completion subcli
+    parser_completion = subparsers.add_parser(
+        "completion",
+        description=(
+            "Print a shell completion script for the requested shell to "
+            "stdout."
+        ),
+    )
+    parser_completion.add_argument(
+        "shell",
+        choices=SUPPORTED_SHELLS,
+        help="shell to generate completion for",
+    )
+    parser_completion.set_defaults(main=completion)
+
     return parser
 
 
@@ -706,6 +737,21 @@ def main(
         logger.debug("changed working directory to %s", args.cwd)
 
     args.main(args, parser)
+
+
+def cli_entry() -> None:
+    """Console-script entry; used by [project.scripts] = pyproject-installer.
+
+    Checks for the ``_PYPROJECT_INSTALLER_COMPLETE`` sentinel set by the
+    bash completion wrapper. When present, hands off to the
+    autocomplete runtime (which reads ``COMP_WORDS`` / ``COMP_CWORD``
+    from the environment, prints candidates, and exits) BEFORE normal
+    argparse processing runs. Otherwise behaves as the standard entry
+    point with ``prog="pyproject-installer"``.
+    """
+    if os.environ.get("_PYPROJECT_INSTALLER_COMPLETE") == "1":
+        run_autocomplete(main_parser("pyproject-installer"))
+    main(sys.argv[1:], prog="pyproject-installer")
 
 
 if __name__ == "__main__":

--- a/src/pyproject_installer/completion_cmd/__init__.py
+++ b/src/pyproject_installer/completion_cmd/__init__.py
@@ -1,0 +1,19 @@
+from collections.abc import Callable
+
+from . import _bash
+
+__all__ = ["SUPPORTED_SHELLS", "completion_command"]
+
+
+SUPPORTED_SHELLS: dict[str, Callable[[], None]] = {
+    "bash": _bash.emit,
+}
+
+
+def completion_command(shell: str) -> None:
+    """Dispatch a `completion <shell>` request to the right emitter."""
+    try:
+        emitter = SUPPORTED_SHELLS[shell]
+    except KeyError:
+        raise ValueError(f"unsupported shell: {shell!r}") from None
+    emitter()

--- a/src/pyproject_installer/completion_cmd/_autocomplete.py
+++ b/src/pyproject_installer/completion_cmd/_autocomplete.py
@@ -1,0 +1,410 @@
+"""Runtime bash-completion handler.
+
+Called by ``cli_entry`` when the bash wrapper sets
+``_PYPROJECT_INSTALLER_COMPLETE=1``. Reads ``COMP_WORDS`` /
+``COMP_CWORD``, prints candidates to stdout, exits. See
+``docs/designs/bash_completion.md`` for the rationale.
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from typing import NoReturn
+
+
+def _path_candidates(current_word: str, *, dirs_only: bool) -> list[str]:
+    """Filesystem paths matching ``current_word`` as prefix.
+
+    Directories get a trailing ``/`` so bash treats them as continuation
+    points; files are filtered out when ``dirs_only`` is True.
+
+    Examples (cwd contains ``dir_a/``, ``dir_b/``, ``file_c``):
+
+        _path_candidates("",     dirs_only=False) -> dir_a/, dir_b/, file_c
+        _path_candidates("",     dirs_only=True)  -> dir_a/, dir_b/
+        _path_candidates("dir_", dirs_only=True)  -> dir_a/, dir_b/
+        _path_candidates("src/", dirs_only=False) -> src/<name>, ...
+    """
+    head, sep, name_prefix = current_word.rpartition(os.sep)
+    parent = Path(head) if head else Path()
+    try:
+        matches = sorted(parent.glob(name_prefix + "*"))
+    except OSError:
+        return []
+    result = []
+    for match in matches:
+        display = f"{head}{sep}{match.name}" if sep else match.name
+        if match.is_dir():
+            result.append(display + "/")
+        elif not dirs_only:
+            result.append(display)
+    return result
+
+
+def _value_candidates(
+    action: argparse.Action,
+    current_word: str,
+) -> list[str]:
+    """Candidates for an argument's VALUE.
+
+    Priority: ``action.choices`` -> path completion driven by
+    ``action.metavar`` -> empty. The metavar string is consulted
+    case-insensitively: ``DIR`` means directories, ``FILE`` or
+    ``PATH`` means files. Other (or absent) metavar means opaque
+    string -> no candidates (bash offers nothing, no misleading
+    filename fallback).
+
+    To enable directory or file completion for a new option, just
+    declare ``metavar="DIR"`` or ``metavar="FILE"`` on its
+    ``add_argument`` call.
+    """
+    if action.choices:
+        return sorted(str(c) for c in action.choices)
+    metavar = action.metavar
+    # argparse allows tuple metavars (per-position, for nargs > 1).
+    # Only the single-string form drives path completion here.
+    if not isinstance(metavar, str):
+        return []
+    metavar = metavar.upper()
+    if metavar == "DIR":
+        return _path_candidates(current_word, dirs_only=True)
+    if metavar in ("FILE", "PATH"):
+        return _path_candidates(current_word, dirs_only=False)
+    return []
+
+
+def _find_subparsers_action(
+    parser: argparse.ArgumentParser,
+) -> "argparse._SubParsersAction[argparse.ArgumentParser] | None":
+    """Return *parser*'s SubParsersAction, or None if it has no subparsers.
+
+    The SubParsersAction is the special argparse action registered by
+    ``parser.add_subparsers()``; its ``.choices`` dict maps subcommand
+    name -> child parser, which :func:`_find_active_parser` walks into.
+    """
+    return next(
+        (
+            a
+            for a in parser._actions  # noqa: SLF001
+            if isinstance(a, argparse._SubParsersAction)  # noqa: SLF001
+        ),
+        None,
+    )
+
+
+def _find_active_parser(
+    parser: argparse.ArgumentParser,
+    typed_words: list[str],
+) -> tuple[argparse.ArgumentParser, list[str]]:
+    """Find which parser the cursor is currently inside.
+
+    Reads *typed_words* left-to-right; each word that names a subparser
+    on the current parser steps into that subparser. The walk stops at
+    the first word that ISN'T a subparser name (or when the current
+    parser has no subparsers); everything from that point on is the
+    active parser's own argv.
+
+    Returns ``(active_parser, parser_argv)``.
+
+    Examples (for a parser tree ``root -> {build, install, deps}``
+    and ``deps -> {add, show, sync}``)::
+
+        typed_words=[]                    -> (root, [])
+        typed_words=["bui"]               -> (root, ["bui"])
+            # "bui" isn't a subparser name; root keeps it
+        typed_words=["build"]             -> (build_parser, [])
+        typed_words=["build", "--outdir", "/tmp"]
+                                  -> (build_parser, ["--outdir", "/tmp"])
+        typed_words=["deps", "add", "myname"]
+                                  -> (add_parser, ["myname"])
+            # Walks root -> deps -> add, leaves "myname" as add's argv
+        typed_words=["unknown"]           -> (root, ["unknown"])
+            # Unknown subcommand: walk stops immediately
+    """
+    active_parser = parser
+    i = 0
+    while i < len(typed_words):
+        subparser_action = _find_subparsers_action(active_parser)
+        if (
+            subparser_action is None
+            or typed_words[i] not in subparser_action.choices
+        ):
+            break
+        active_parser = subparser_action.choices[typed_words[i]]
+        i += 1
+    return active_parser, typed_words[i:]
+
+
+def _value_taking_options(
+    parser: argparse.ArgumentParser,
+) -> list[argparse.Action]:
+    """Options on *parser* that take a value (not store_true/count/etc.)."""
+    # argparse nargs for an action that consumes no value words.
+    # Naming the literal sidesteps pylint C1805; `not a.nargs` would be
+    # wrong because nargs can also be None ("exactly one") or "?"/"*"/"+",
+    # all falsey.
+    no_value = 0
+    return [
+        a
+        for a in parser._actions  # noqa: SLF001
+        if a.option_strings and a.nargs != no_value
+    ]
+
+
+def _option_names(parser: argparse.ArgumentParser) -> list[str]:
+    """Sorted list of every option string on *parser* (long + short)."""
+    return sorted(
+        {
+            opt
+            for a in parser._actions  # noqa: SLF001
+            if not isinstance(a, argparse._SubParsersAction)  # noqa: SLF001
+            for opt in a.option_strings
+        },
+    )
+
+
+# Argparse actions designed for repeated use on a single command line.
+# `append`, `append_const`, `count`, `extend` accumulate across uses;
+# everything else (store, store_true/false/const, help, version, ...) is
+# single-shot - a second occurrence either overrides the first or is a
+# no-op, so the completion handler stops offering them once they're typed.
+_REPEATABLE_ACTIONS: tuple[type[argparse.Action], ...] = (
+    argparse._AppendAction,  # noqa: SLF001
+    argparse._AppendConstAction,  # noqa: SLF001
+    argparse._CountAction,  # noqa: SLF001
+    argparse._ExtendAction,  # noqa: SLF001
+)
+
+# Argparse actions that print and call ``parser.exit()`` immediately.
+# Once one of these is on the line, the binary will exit before reaching
+# anything the user might type next, so completion offers nothing.
+_TERMINATING_ACTIONS: tuple[type[argparse.Action], ...] = (
+    argparse._HelpAction,  # noqa: SLF001
+    argparse._VersionAction,  # noqa: SLF001
+)
+
+
+def _has_terminating_option(
+    parser: argparse.ArgumentParser,
+    parser_argv: list[str],
+) -> bool:
+    """Whether *parser_argv* contains a help-style terminating option."""
+    return any(
+        opt in parser_argv
+        for action in parser._actions  # noqa: SLF001
+        if isinstance(action, _TERMINATING_ACTIONS)
+        for opt in action.option_strings
+    )
+
+
+def _option_name_candidates(
+    parser: argparse.ArgumentParser,
+    parser_argv: list[str],
+) -> list[str]:
+    """Option names already on the line or rejected by argparse are dropped.
+
+    Two suppression rules apply:
+
+    1. Mutually-exclusive groups: if any member of a group is already
+       on the command line, every member is dropped - siblings because
+       argparse would reject them, and the typed member itself because
+       re-offering it is misleading (re-typing a store_true does
+       nothing; re-typing a value option just creates clutter).
+    2. Non-repeatable single-shot options: any option whose action
+       isn't one of ``append``/``append_const``/``count``/``extend``
+       is dropped from the candidate list once it (or any of its
+       aliases) appears in *parser_argv*. So once ``--help`` has
+       been typed, neither ``--help`` nor ``-h`` is offered again;
+       but ``count``-style ``-v`` stays available so the user can
+       stack ``-v -v``.
+
+    Generic over all parsers.
+    """
+    suppressed: set[str] = set()
+    for group in parser._mutually_exclusive_groups:  # noqa: SLF001
+        members = [
+            list(a.option_strings)
+            for a in group._group_actions  # noqa: SLF001
+            if a.option_strings
+        ]
+        any_present = any(
+            opt in parser_argv for member in members for opt in member
+        )
+        if any_present:
+            suppressed.update(opt for member in members for opt in member)
+    for action in parser._actions:  # noqa: SLF001
+        if not action.option_strings:
+            continue
+        if isinstance(action, _REPEATABLE_ACTIONS):
+            continue
+        if any(opt in parser_argv for opt in action.option_strings):
+            suppressed.update(action.option_strings)
+    return [f for f in _option_names(parser) if f not in suppressed]
+
+
+def _positional_candidates(
+    parser: argparse.ArgumentParser,
+    parser_argv: list[str],
+    value_option_names: set[str],
+    current_word: str,
+) -> list[str]:
+    """Candidates for the current positional slot.
+
+    Counts non-option words in *parser_argv* (skipping the word that
+    immediately follows any value-taking option) to determine the cursor's
+    slot index, then dispatches to that slot's action. Beyond the fixed
+    slots a trailing variadic positional (``nargs in {"*","+"}``)
+    absorbs every remaining slot.
+    """
+    positionals = [
+        a
+        for a in parser._actions  # noqa: SLF001
+        if not a.option_strings
+        and not isinstance(a, argparse._SubParsersAction)  # noqa: SLF001
+    ]
+    if not positionals:
+        return []
+
+    slot = 0
+    skip_next = False
+    past_double_dash = False
+    for word in parser_argv:
+        if skip_next:
+            skip_next = False
+            continue
+        # The first bare ``--`` ends option parsing in argparse; every
+        # word after it is positional even if it looks option-like.
+        if word == "--" and not past_double_dash:
+            past_double_dash = True
+            continue
+        if not past_double_dash and word.startswith("-"):
+            skip_next = word in value_option_names
+            continue
+        slot += 1
+
+    if slot < len(positionals):
+        return _value_candidates(positionals[slot], current_word)
+    if positionals[-1].nargs in ("*", "+"):
+        return _value_candidates(positionals[-1], current_word)
+    return []
+
+
+def compute_candidates(
+    parser: argparse.ArgumentParser,
+    command_words: list[str],
+    current_word_index: int,
+) -> list[str]:
+    """Compute candidate completions for one TAB press.
+
+    Pure function: given the command_words array (COMP_WORDS, split on
+    whitespace) and the cursor index (COMP_CWORD), returns the candidates
+    that match the current word's prefix.
+
+    Four-way dispatch on context:
+
+    1. ``prev_word`` is a value-taking option -> complete that option's VALUE.
+    2. ``current_word`` starts with ``-`` -> option names
+       (mutually-exclusive siblings suppressed).
+    3. Active parser has subparsers -> subcommand names + parent option names.
+    4. Otherwise -> positional slot dispatch, falling back to option
+       names when there's no positional candidate to offer.
+
+    A bare ``--`` already on the line ends option parsing (argparse
+    convention): once seen, branches 1, 2 and the branch-4 option-name
+    fallback all suppress themselves, so completion only offers
+    remaining positional candidates (or nothing if those are exhausted).
+    """
+    n_words = len(command_words)
+    current_word = (
+        command_words[current_word_index]
+        if current_word_index < n_words
+        else ""
+    )
+    prev_word = (
+        command_words[current_word_index - 1]
+        if 0 < current_word_index <= n_words
+        else ""
+    )
+    active_parser, parser_argv = _find_active_parser(
+        parser,
+        command_words[1:current_word_index],
+    )
+    # A help-style action (``--help``, ``--version``) on the line means
+    # argparse will print and exit before reaching the cursor; nothing
+    # the user types next will run, so offer no candidates.
+    if _has_terminating_option(active_parser, parser_argv):
+        return []
+    value_options = _value_taking_options(active_parser)
+    past_double_dash = "--" in parser_argv
+
+    # 1. Value-option context.
+    if prev_word.startswith("-") and not past_double_dash:
+        option = next(
+            (a for a in value_options if prev_word in a.option_strings),
+            None,
+        )
+        if option is not None:
+            candidates = _value_candidates(option, current_word)
+            return [c for c in candidates if c.startswith(current_word)]
+
+    # 2. Option-name context.
+    if current_word.startswith("-") and not past_double_dash:
+        candidates = _option_name_candidates(active_parser, parser_argv)
+        return [c for c in candidates if c.startswith(current_word)]
+
+    # 3. Subcommand context.
+    subparser_action = _find_subparsers_action(active_parser)
+    if subparser_action is not None:
+        candidates = sorted(
+            subparser_action.choices,
+        ) + _option_name_candidates(active_parser, parser_argv)
+        return [c for c in candidates if c.startswith(current_word)]
+
+    # 4. Positional dispatch, falling back to option names.
+    value_option_names = {
+        opt for a in value_options for opt in a.option_strings
+    }
+    candidates = _positional_candidates(
+        active_parser,
+        parser_argv,
+        value_option_names,
+        current_word,
+    )
+    if not candidates and not past_double_dash:
+        # No positional to dispatch to (no positionals at all, a FREE
+        # positional, or slot past the fixed ones with no variadic).
+        # Offer the parser's options instead so the user sees something
+        # actionable instead of an empty completion. Past a bare ``--``,
+        # argparse rejects further options so the fallback is suppressed.
+        candidates = _option_name_candidates(active_parser, parser_argv)
+    return [c for c in candidates if c.startswith(current_word)]
+
+
+def run_autocomplete(parser: argparse.ArgumentParser) -> NoReturn:
+    """Entry point invoked from ``cli_entry`` when the env var is set.
+
+    Reads ``COMP_WORDS`` and ``COMP_CWORD`` from the environment, prints
+    each candidate from :func:`compute_candidates` on its own line, and
+    exits. Bash captures the lines into the ``COMPREPLY`` array
+    (newline is in the default ``IFS``); the columnar display you see
+    on ``<TAB><TAB>`` is bash's default formatting of that array, not
+    how this function emits.
+
+    Exit codes:
+      - 0 on success (zero or more candidates printed)
+      - 1 if the env vars are missing or malformed
+    """
+    try:
+        command_words = os.environ["COMP_WORDS"].split()
+        current_word_index = int(os.environ["COMP_CWORD"])
+    except (KeyError, ValueError):
+        sys.exit(1)
+    candidates = compute_candidates(
+        parser,
+        command_words,
+        current_word_index,
+    )
+    for candidate in candidates:
+        sys.stdout.write(candidate + "\n")
+    sys.exit(0)

--- a/src/pyproject_installer/completion_cmd/_bash.py
+++ b/src/pyproject_installer/completion_cmd/_bash.py
@@ -1,0 +1,25 @@
+"""Emit the bash completion script.
+
+The script is a fixed shim that calls ``pyproject-installer`` back at
+TAB time; ``cli_entry`` detects the sentinel env var and routes to
+:func:`._autocomplete.run_autocomplete`, which computes the
+candidates. See ``docs/designs/bash_completion.md`` for the rationale.
+"""
+
+import sys
+
+SCRIPT_TEMPLATE = """\
+_pyproject_installer()
+{
+    local IFS=$' \\t\\n'
+    COMPREPLY=( $( COMP_WORDS="${COMP_WORDS[*]}" \\
+                   COMP_CWORD=$COMP_CWORD \\
+                   _PYPROJECT_INSTALLER_COMPLETE=1 "$1" 2>/dev/null ) )
+}
+complete -o nosort -F _pyproject_installer pyproject-installer
+"""
+
+
+def emit() -> None:
+    """Write the bash completion script to stdout."""
+    sys.stdout.write(SCRIPT_TEMPLATE)

--- a/tests/unit/test_completion/test_autocomplete.py
+++ b/tests/unit/test_completion/test_autocomplete.py
@@ -1,0 +1,60 @@
+"""Tests for run_autocomplete from completion_cmd/_autocomplete.py."""
+
+import argparse
+
+import pytest
+
+from pyproject_installer.completion_cmd import _autocomplete as ac
+
+
+def test_run_autocomplete_missing_comp_words(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """run_autocomplete exits 1 when COMP_WORDS is unset."""
+    monkeypatch.delenv("COMP_WORDS", raising=False)
+    with pytest.raises(SystemExit) as exc:
+        ac.run_autocomplete(argparse.ArgumentParser(prog="demo"))
+    assert exc.value.code == 1
+
+
+def test_run_autocomplete_missing_comp_cword(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """run_autocomplete exits 1 when COMP_CWORD is unset."""
+    monkeypatch.delenv("COMP_CWORD", raising=False)
+    with pytest.raises(SystemExit) as exc:
+        ac.run_autocomplete(argparse.ArgumentParser(prog="demo"))
+    assert exc.value.code == 1
+
+
+def test_run_autocomplete_malformed_cword(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """run_autocomplete exits 1 when COMP_CWORD isn't a valid integer."""
+    monkeypatch.setenv("COMP_WORDS", "demo ")
+    monkeypatch.setenv("COMP_CWORD", "not_an_int")
+    with pytest.raises(SystemExit) as exc:
+        ac.run_autocomplete(argparse.ArgumentParser(prog="demo"))
+    assert exc.value.code == 1
+
+
+def test_run_autocomplete_prints_candidates_and_exits_0(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """run_autocomplete prints one candidate per line and exits 0."""
+    monkeypatch.setenv("COMP_WORDS", "demo ")
+    monkeypatch.setenv("COMP_CWORD", "1")
+    parser = argparse.ArgumentParser(prog="demo")
+    sub = parser.add_subparsers(required=True)
+    sub.add_parser("add")
+    sub.add_parser("build")
+    with pytest.raises(SystemExit) as exc:
+        ac.run_autocomplete(parser)
+    # move here for pylint
+    success = 0
+    assert exc.value.code == success
+    # stripping trailing \n
+    out = capsys.readouterr().out.rstrip()
+    actual = out.split("\n")
+    assert actual == ["add", "build", "--help", "-h"]

--- a/tests/unit/test_completion/test_autocomplete_parser.py
+++ b/tests/unit/test_completion/test_autocomplete_parser.py
@@ -1,0 +1,451 @@
+"""Tests for argparse parser from completion_cmd/_autocomplete.py."""
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from pyproject_installer.completion_cmd import _autocomplete as ac
+
+
+@pytest.fixture
+def cwd_with_dirs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """tmp_path containing two dirs and one file; chdir into it.
+
+    Used by path-completion tests so the expected candidate list is
+    deterministic instead of depending on the host cwd.
+    """
+    (tmp_path / "dir_a").mkdir()
+    (tmp_path / "dir_b").mkdir()
+    (tmp_path / "file_c").touch()
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+@pytest.fixture(scope="session")
+def parser() -> argparse.ArgumentParser:
+    """A synthetic parser mirroring the real CLI's shape.
+
+    Includes: top-level global options (-v, -C), a leaf subcommand
+    (build) with value-taking options and a Path positional, a subcommand
+    with choices (add), a subcommand group (deps) with second-level
+    subcommands.
+    """
+    p = argparse.ArgumentParser(prog="demo")
+    p.add_argument("-v", "--verbose", action="store_true")
+    p.add_argument("-C", dest="cwd", metavar="DIR")
+    sub = p.add_subparsers(required=True)
+
+    build = sub.add_parser("build")
+    build.add_argument("srcdir", type=Path, nargs="?", metavar="DIR")
+    build.add_argument("--outdir", "-o", type=Path, metavar="DIR")
+    build.add_argument("--sdist", action="store_true")
+
+    add = sub.add_parser("add")
+    add.add_argument("srctype", choices=("a", "b", "c"))
+
+    deps = sub.add_parser("deps")
+    deps.add_argument("--depsconfig", type=Path, metavar="FILE")
+    deps_sub = deps.add_subparsers(required=True)
+    deps_show = deps_sub.add_parser("show")
+    deps_show.add_argument("names", nargs="*")
+    deps_sync = deps_sub.add_parser("sync")
+    deps_sync.add_argument("--verify", action="store_true")
+    return p
+
+
+@pytest.fixture(scope="session")
+def double_dash_parser() -> argparse.ArgumentParser:
+    """Parser used by the ``--`` sentinel tests: one FILE positional + opts."""
+    parser = argparse.ArgumentParser(prog="demo")
+    sub = parser.add_subparsers()
+    inst = sub.add_parser("inst")
+    inst.add_argument("wheel", type=Path, nargs="?", metavar="FILE")
+    inst.add_argument("--destdir", type=Path, metavar="DIR")
+    inst.add_argument("--installer")  # opaque value
+    return parser
+
+
+def candidates(parser: argparse.ArgumentParser, words: list[str]) -> list[str]:
+    """Compute candidates with cursor at the LAST word (typical TAB)."""
+    return ac.compute_candidates(parser, words, len(words) - 1)
+
+
+def test_compute_top_level_no_input_offers_subcommands_and_options(
+    parser: argparse.ArgumentParser,
+) -> None:
+    """Top-level ``<TAB>`` offers sorted subcommands then option names."""
+    assert candidates(parser, ["demo", ""]) == [
+        "add",
+        "build",
+        "deps",
+        "--help",
+        "--verbose",
+        "-C",
+        "-h",
+        "-v",
+    ]
+
+
+def test_compute_top_level_filter_by_prefix(
+    parser: argparse.ArgumentParser,
+) -> None:
+    """Top-level candidates are filtered by the current word as a prefix."""
+    assert candidates(parser, ["demo", "bu"]) == ["build"]
+
+
+def test_compute_dash_prefix_offers_option_names_only(
+    parser: argparse.ArgumentParser,
+) -> None:
+    """A `-`-prefixed current word offers only option names, not subcommands."""
+    # Only the long option names pass the "--" prefix filter; no
+    # subcommand names because cur starts with -.
+    assert candidates(parser, ["demo", "--"]) == ["--help", "--verbose"]
+
+
+@pytest.mark.usefixtures("cwd_with_dirs")
+def test_compute_dash_c_option_offers_directories(
+    parser: argparse.ArgumentParser,
+) -> None:
+    """Global `-C <TAB>` offers directories (driven by metavar=DIR)."""
+    # prev="-C" with metavar="DIR" -> directory completion. cwd is a
+    # tmp dir with two dirs and one file; only the dirs (sorted, with
+    # trailing /) are offered.
+    assert candidates(parser, ["demo", "-C", ""]) == ["dir_a/", "dir_b/"]
+
+
+@pytest.mark.usefixtures("cwd_with_dirs")
+def test_compute_subcommand_value_option_offers_dirs(
+    parser: argparse.ArgumentParser,
+) -> None:
+    """Value-taking option with metavar=DIR offers directory candidates."""
+    # `build --outdir <TAB>` -> directory completion in cwd_with_dirs.
+    assert candidates(parser, ["demo", "build", "--outdir", ""]) == [
+        "dir_a/",
+        "dir_b/",
+    ]
+
+
+def test_compute_subcommand_positional_choices_at_slot_zero(
+    parser: argparse.ArgumentParser,
+) -> None:
+    """A subcommand positional with `choices=` completes from those choices."""
+    # `add <TAB>` -> slot 0 is `srctype` with choices.
+    assert candidates(parser, ["demo", "add", ""]) == ["a", "b", "c"]
+
+
+def test_compute_subcommand_positional_choices_filtered_by_prefix(
+    parser: argparse.ArgumentParser,
+) -> None:
+    """Positional choices are filtered by the current word's prefix."""
+    assert candidates(parser, ["demo", "add", "b"]) == ["b"]
+
+
+def test_compute_free_positional_falls_back_to_options() -> None:
+    """A FREE positional offers no value candidates -> options as fallback."""
+    parser = argparse.ArgumentParser(prog="demo")
+    sub = parser.add_subparsers()
+    leaf = sub.add_parser("foo")
+    leaf.add_argument("name")  # FREE positional
+    assert candidates(parser, ["demo", "foo", ""]) == ["--help", "-h"]
+
+
+@pytest.mark.usefixtures("cwd_with_dirs")
+def test_compute_value_option_token_is_skipped_for_positional_counter() -> None:
+    """Tokens consumed by value-taking options don't count as positionals."""
+    parser = argparse.ArgumentParser(prog="demo")
+    sub = parser.add_subparsers()
+    b = sub.add_parser("b")
+    b.add_argument("--outdir", "-o", type=Path, metavar="DIR")
+    b.add_argument("srcdir", type=Path, nargs="?", metavar="DIR")
+    b.add_argument("kind", choices=("x", "y"))
+    # `b --outdir /tmp <TAB>` -> srcdir slot, not kind slot. srcdir
+    # is metavar="DIR" so candidates are cwd dirs (cwd_with_dirs).
+    typed = ["demo", "b", "--outdir", "/somedir", ""]
+    assert candidates(parser, typed) == ["dir_a/", "dir_b/"]
+
+
+def test_compute_non_repeatable_option_already_typed_is_suppressed(
+    parser: argparse.ArgumentParser,
+) -> None:
+    """A non-repeatable option drops out of candidates once on the line."""
+    # --verbose is store_true on the fixture parser; typing it then
+    # --<TAB> must NOT re-offer --verbose (or -v alias).
+    assert candidates(parser, ["demo", "--verbose", "--"]) == ["--help"]
+
+
+def test_compute_non_repeatable_option_short_alias_suppresses_long(
+    parser: argparse.ArgumentParser,
+) -> None:
+    """Typing one alias of a non-repeatable option suppresses every alias."""
+    # Typing -v (the short alias of --verbose) must also drop --verbose.
+    assert candidates(parser, ["demo", "-v", "--"]) == ["--help"]
+
+
+def test_compute_help_terminates_completion(
+    parser: argparse.ArgumentParser,
+) -> None:
+    """``--help`` makes argparse exit; nothing is reachable after it."""
+    assert candidates(parser, ["demo", "--help", ""]) == []
+    assert candidates(parser, ["demo", "--help", "-"]) == []
+    assert candidates(parser, ["demo", "--help", "build", ""]) == []
+
+
+def test_compute_short_help_alias_also_terminates(
+    parser: argparse.ArgumentParser,
+) -> None:
+    """``-h`` is the short alias of ``--help``; same terminating effect."""
+    assert candidates(parser, ["demo", "-h", ""]) == []
+
+
+def test_compute_version_terminates_completion() -> None:
+    """``--version`` prints and exits; no candidates after it either."""
+    # The shared parser fixture has no --version, so build a one-off.
+    parser = argparse.ArgumentParser(prog="demo")
+    parser.add_argument("--version", action="version", version="0.1")
+    parser.add_argument("--other", action="store_true")
+    assert candidates(parser, ["demo", "--version", ""]) == []
+
+
+def test_compute_subparser_help_terminates_completion(
+    parser: argparse.ArgumentParser,
+) -> None:
+    """``--help`` registered on a subparser also terminates dispatch there."""
+    # build's own --help -> after walking into build, the check fires.
+    assert candidates(parser, ["demo", "build", "--help", ""]) == []
+    assert candidates(parser, ["demo", "build", "--help", "--"]) == []
+
+
+def test_compute_count_action_stays_offered() -> None:
+    """``action='count'`` is repeatable -> still offered after first use."""
+    parser = argparse.ArgumentParser(prog="demo")
+    parser.add_argument("-v", action="count")
+    # -v already typed; count actions stack (-v -v -v), so re-offer.
+    assert candidates(parser, ["demo", "-v", "-"]) == ["--help", "-h", "-v"]
+
+
+def test_compute_append_action_stays_offered() -> None:
+    """``action='append'`` is repeatable -> still offered after first use."""
+    parser = argparse.ArgumentParser(prog="demo")
+    parser.add_argument("--tag", action="append")
+    # --tag x already typed; append actions accumulate, so re-offer.
+    assert candidates(parser, ["demo", "--tag", "x", "--"]) == [
+        "--help",
+        "--tag",
+    ]
+
+
+def test_compute_store_option_with_value_is_suppressed() -> None:
+    """A regular ``store`` option is single-shot -> drops once present."""
+    parser = argparse.ArgumentParser(prog="demo")
+    parser.add_argument("--outdir")
+    # Even though argparse would accept a second --outdir (overrides),
+    # completion treats it as non-repeatable to avoid clutter.
+    assert candidates(parser, ["demo", "--outdir", "x", "--"]) == ["--help"]
+
+
+def test_compute_mutually_exclusive_group_is_suppressed_whole() -> None:
+    """A present member drops every member of that group (including itself)."""
+    parser = argparse.ArgumentParser(prog="demo")
+    sub = parser.add_subparsers()
+    inst = sub.add_parser("inst")
+    g = inst.add_mutually_exclusive_group()
+    g.add_argument("--platlib", action="store_true")
+    g.add_argument("--purelib", action="store_true")
+    inst.add_argument("--other", action="store_true")
+    # --purelib gone (sibling argparse would reject); --platlib gone too
+    # (re-typing a store_true is pointless); --other unaffected; auto --help.
+    assert candidates(parser, ["demo", "inst", "--platlib", "--"]) == [
+        "--help",
+        "--other",
+    ]
+
+
+def test_compute_subcommand_group_offers_grouped_subcommands(
+    parser: argparse.ArgumentParser,
+) -> None:
+    """`deps <TAB>` offers grouped subcommands then deps's options."""
+    assert candidates(parser, ["demo", "deps", ""]) == [
+        "show",
+        "sync",
+        "--depsconfig",
+        "--help",
+        "-h",
+    ]
+
+
+def test_compute_grouped_subcommand_positional(
+    parser: argparse.ArgumentParser,
+) -> None:
+    """`deps show <TAB>` -> `names` is FREE nargs=*; falls back to options."""
+    assert candidates(parser, ["demo", "deps", "show", ""]) == [
+        "--help",
+        "-h",
+    ]
+
+
+def test_compute_grouped_subcommand_option_completion(
+    parser: argparse.ArgumentParser,
+) -> None:
+    """`deps sync --<TAB>` -> sync's long options (auto --help + --verify)."""
+    assert candidates(parser, ["demo", "deps", "sync", "--"]) == [
+        "--help",
+        "--verify",
+    ]
+
+
+def test_compute_variadic_nargs_star() -> None:
+    """nargs='*' last positional absorbs all further slots."""
+    parser = argparse.ArgumentParser(prog="demo")
+    sub = parser.add_subparsers()
+    show = sub.add_parser("show")
+    show.add_argument("kind", choices=("a", "b"))
+    show.add_argument("names", nargs="*", choices=("x", "y"))
+    # Slot 0 = kind
+    assert candidates(parser, ["demo", "show", ""]) == ["a", "b"]
+    # Slot 1+ = names (variadic)
+    assert candidates(parser, ["demo", "show", "a", ""]) == ["x", "y"]
+    assert candidates(parser, ["demo", "show", "a", "x", ""]) == ["x", "y"]
+
+
+def test_compute_missing_env_returns_empty(
+    parser: argparse.ArgumentParser,
+) -> None:
+    """When cword is past the end of words, cur defaults to empty.
+
+    Result is the same as the no-input top-level case: sorted
+    subcommands + sorted option names, no prefix filter.
+    """
+    # cword=5 with only 2 words -> cur=""
+    expected = ["add", "build", "deps", "--help", "--verbose", "-C", "-h", "-v"]
+    assert ac.compute_candidates(parser, ["demo", ""], 5) == expected
+
+
+@pytest.mark.usefixtures("cwd_with_dirs")
+def test_compute_subcommand_value_option_with_file_metavar_offers_files(
+    parser: argparse.ArgumentParser,
+) -> None:
+    """Value-taking option with metavar=FILE offers dirs AND regular files."""
+    # `deps --depsconfig <TAB>` -> FILE completion: dirs (trailing /)
+    # AND files (cwd_with_dirs has two dirs and one file).
+    assert candidates(parser, ["demo", "deps", "--depsconfig", ""]) == [
+        "dir_a/",
+        "dir_b/",
+        "file_c",
+    ]
+
+
+def test_compute_value_option_with_unknown_metavar_offers_nothing() -> None:
+    """A metavar outside DIR/FILE/PATH yields no path candidates."""
+    parser = argparse.ArgumentParser(prog="demo")
+    sub = parser.add_subparsers()
+    leaf = sub.add_parser("show")
+    leaf.add_argument("--pattern", metavar="PATTERN")
+    # `show --pattern <TAB>` -> opaque string, no completion.
+    assert candidates(parser, ["demo", "show", "--pattern", ""]) == []
+
+
+def test_compute_path_candidates_swallow_oserror(mocker) -> None:
+    """Unreadable parent directory yields empty candidates, not a crash."""
+    mock_path = mocker.patch.object(ac, "Path")
+    mock_path.return_value.glob.side_effect = PermissionError("simulated")
+    parser = argparse.ArgumentParser(prog="demo")
+    sub = parser.add_subparsers()
+    leaf = sub.add_parser("show")
+    leaf.add_argument("--config", metavar="FILE")
+    assert candidates(parser, ["demo", "show", "--config", ""]) == []
+
+
+def test_compute_positional_in_subcommand_with_no_positionals() -> None:
+    """Leaf with only options offers them as the cur='' fallback."""
+    parser = argparse.ArgumentParser(prog="demo")
+    sub = parser.add_subparsers()
+    leaf = sub.add_parser("noargs")
+    leaf.add_argument("--option", action="store_true")
+    # No positional to dispatch to -> option-name fallback.
+    assert candidates(parser, ["demo", "noargs", ""]) == [
+        "--help",
+        "--option",
+        "-h",
+    ]
+
+
+def test_compute_positional_beyond_fixed_slots_falls_back_to_options() -> None:
+    """Past last fixed positional with no variadic -> option-name fallback."""
+    parser = argparse.ArgumentParser(prog="demo")
+    sub = parser.add_subparsers()
+    leaf = sub.add_parser("pick")
+    leaf.add_argument("one", choices=("a", "b"))
+    # Slot 1 is past the only positional; no variadic to absorb ->
+    # falls back to option names.
+    assert candidates(parser, ["demo", "pick", "a", ""]) == ["--help", "-h"]
+
+
+@pytest.mark.usefixtures("cwd_with_dirs")
+def test_compute_double_dash_then_empty_offers_positional(
+    double_dash_parser: argparse.ArgumentParser,
+) -> None:
+    """``inst -- <TAB>``: cursor past --, wheel slot still empty -> FILE."""
+    assert candidates(double_dash_parser, ["demo", "inst", "--", ""]) == [
+        "dir_a/",
+        "dir_b/",
+        "file_c",
+    ]
+
+
+def test_compute_double_dash_then_filled_positional_offers_nothing(
+    double_dash_parser: argparse.ArgumentParser,
+) -> None:
+    """``inst -- some.whl <TAB>``: positional filled, no fallback to options."""
+    # Post-`--`, the wheel slot is filled; no more positionals exist
+    # and the option-name fallback is suppressed -> empty completion.
+    assert (
+        candidates(double_dash_parser, ["demo", "inst", "--", "some.whl", ""])
+        == []
+    )
+
+
+def test_compute_double_dash_then_option_looking_word_offers_nothing(
+    double_dash_parser: argparse.ArgumentParser,
+) -> None:
+    """Words after ``--`` count as positionals even when option-shaped."""
+    # ``--some-file.whl`` is the wheel value (not an option); slot filled.
+    assert (
+        candidates(
+            double_dash_parser,
+            ["demo", "inst", "--", "--some-file.whl", ""],
+        )
+        == []
+    )
+
+
+def test_compute_double_dash_suppresses_option_name_context(
+    double_dash_parser: argparse.ArgumentParser,
+) -> None:
+    """``inst -- --<TAB>``: branch 2 silenced -> empty, not option names."""
+    assert candidates(double_dash_parser, ["demo", "inst", "--", "--"]) == []
+
+
+def test_compute_double_dash_suppresses_value_option_context(
+    double_dash_parser: argparse.ArgumentParser,
+) -> None:
+    """``inst -- --destdir <TAB>``: prev=--destdir is a positional, not opt."""
+    # Without --, prev=--destdir would dispatch to directory candidates.
+    # Past --, --destdir is the wheel value; slot filled -> empty.
+    assert (
+        candidates(double_dash_parser, ["demo", "inst", "--", "--destdir", ""])
+        == []
+    )
+
+
+@pytest.mark.usefixtures("cwd_with_dirs")
+def test_compute_option_before_double_dash_still_consumes_value(
+    double_dash_parser: argparse.ArgumentParser,
+) -> None:
+    """``inst --destdir /tmp -- <TAB>``: value-opt slot ok, wheel still open."""
+    # --destdir consumed /tmp (slot counter skips both), then `--` ends
+    # option parsing; wheel slot is still empty -> FILE candidates.
+    assert candidates(
+        double_dash_parser,
+        ["demo", "inst", "--destdir", "/somedir", "--", ""],
+    ) == ["dir_a/", "dir_b/", "file_c"]

--- a/tests/unit/test_completion/test_bash.py
+++ b/tests/unit/test_completion/test_bash.py
@@ -1,0 +1,46 @@
+"""Tests for completion_cmd/_bash.py.
+
+The bash emitter is a fixed string literal targeting the
+``pyproject-installer`` console script; these tests verify the
+wrapper shape. The runtime dispatch logic lives in _autocomplete.py
+and is tested in test_autocomplete.py.
+"""
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from pyproject_installer.completion_cmd import _bash
+
+
+@pytest.fixture(scope="session")
+def bash_completion():
+    return subprocess.check_output(
+        [sys.executable, "-m", "pyproject_installer", "completion", "bash"],
+        text=True,
+    )
+
+
+def test_completion_content(bash_completion) -> None:
+    """Check the content of generated completion"""
+    assert bash_completion == _bash.SCRIPT_TEMPLATE
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash not on PATH")
+def test_completion_is_sourceable_in_bash(
+    bash_completion,
+    tmp_path: Path,
+) -> None:
+    """The generated script must source cleanly and register completion."""
+    script = tmp_path / "wrapper.bash"
+    script.write_text(bash_completion)
+    cmd_str = f"source {script} && complete -p pyproject-installer"
+    cmd = ["bash", "-c", cmd_str]
+    completion_function = subprocess.check_output(cmd, text=True)
+    expected = (
+        "complete -o nosort -F _pyproject_installer pyproject-installer\n"
+    )
+    assert expected == completion_function

--- a/tests/unit/test_completion/test_completion.py
+++ b/tests/unit/test_completion/test_completion.py
@@ -1,0 +1,27 @@
+"""Tests for completion_cmd/__init__.py."""
+
+import pytest
+
+from pyproject_installer.completion_cmd import (
+    SUPPORTED_SHELLS,
+    completion_command,
+)
+
+
+def test_completion_command_unsupported_shell() -> None:
+    """Dispatcher raises ValueError for unknown shells."""
+    shell = "nonexistent_shell"
+    with pytest.raises(ValueError, match=f"unsupported shell: '{shell}'"):
+        completion_command(shell)
+
+
+@pytest.mark.parametrize("shell", SUPPORTED_SHELLS)
+def test_completion_command_supported_shell(
+    shell: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Dispatcher accepts supported shells and emits completion on stdout"""
+    completion_command(shell)
+    captured = capsys.readouterr()
+    assert not captured.err
+    assert captured.out

--- a/tests/unit/test_completion/test_path_metavars.py
+++ b/tests/unit/test_completion/test_path_metavars.py
@@ -1,0 +1,67 @@
+"""Every Path-typed CLI argument must declare a path-flavored metavar.
+
+The autocomplete dispatcher in ``completion_cmd/_autocomplete.py`` picks
+filesystem candidates by reading ``action.metavar``: ``DIR`` -> dirs,
+``FILE``/``PATH`` -> files-and-dirs. An ``add_argument(type=Path)`` call
+without a path-flavored metavar silently breaks TAB-completion for that
+argument because the dispatcher has no signal to offer paths. These
+tests walk the live CLI parser and fail the build before such an arg
+can land.
+"""
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from pyproject_installer.__main__ import main_parser
+
+PATH_METAVARS = frozenset({"DIR", "FILE", "PATH"})
+
+
+def parser_actions(parser: argparse.ArgumentParser) -> list[argparse.Action]:
+    """Every action reachable from *parser*, recursing into subparsers."""
+    actions = list(parser._actions)  # noqa: SLF001
+    for action in parser._actions:  # noqa: SLF001
+        if isinstance(action, argparse._SubParsersAction):  # noqa: SLF001
+            for child in action.choices.values():
+                actions.extend(parser_actions(child))
+    return actions
+
+
+@pytest.fixture(scope="module")
+def path_actions() -> list[argparse.Action]:
+    """Every ``type=Path`` action reachable from the live CLI parser."""
+    parser = main_parser(prog="pyproject-installer")
+    return [a for a in parser_actions(parser) if a.type is Path]
+
+
+def test_cli_has_path_typed_actions(
+    path_actions: list[argparse.Action],
+) -> None:
+    """The CLI declares some Path-typed arguments.
+
+    Guards against a refactor that silently strips them all and makes
+    the metavar rule below vacuously true (no actions to check).
+    """
+    assert path_actions, "expected the CLI to declare type=Path arguments"
+
+
+def test_path_typed_actions_declare_path_metavar(
+    path_actions: list[argparse.Action],
+) -> None:
+    """Every ``type=Path`` action declares a path-flavored metavar.
+
+    Without ``metavar in {DIR, FILE, PATH}`` the completion dispatcher
+    has no signal to offer filesystem candidates for that argument -
+    TAB silently returns nothing.
+    """
+    actions_missing_metavar = [
+        (a.option_strings or [a.dest], a.metavar)
+        for a in path_actions
+        if a.metavar not in PATH_METAVARS
+    ]
+    assert not actions_missing_metavar, (
+        "type=Path actions missing a path-flavored metavar "
+        f"(must be one of {sorted(PATH_METAVARS)}): {actions_missing_metavar}"
+    )

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -39,6 +39,25 @@ def mock_deps_command(mocker):
 
 
 @pytest.fixture
+def mock_completion_command(mocker):
+    return mocker.patch.object(project_main, "completion_command")
+
+
+@pytest.fixture
+def mock_main(mocker):
+    return mocker.patch.object(project_main, "main")
+
+
+@pytest.fixture
+def mock_run_autocomplete(mocker):
+    return mocker.patch.object(
+        project_main,
+        "run_autocomplete",
+        side_effect=SystemExit,
+    )
+
+
+@pytest.fixture
 def mock_read_tracker(mocker):
     return mocker.patch.object(
         project_main.Path,
@@ -70,6 +89,18 @@ def record_cwd():
         return _cwd
 
     return _patch_mocked_cmd
+
+
+def invalid_choice_messages(choice, *, choices):
+    return (
+        f"invalid choice: '{choice}' (choose from {msg})\n"
+        for msg in [
+            # Python 3.12.8/3.13.1+
+            ", ".join(choices),
+            # Python < 3.12.8/3.13.1
+            ", ".join(f"'{x}'" for x in choices),
+        ]
+    )
 
 
 def test_version():
@@ -1626,14 +1657,9 @@ def test_deps_cli_add_wrong_srctype(capsys):
         project_main.main(deps_args)
     assert exc.value.code == ExitCodes.WRONG_USAGE
 
-    expected_err_msgs = (
-        f"invalid choice: '{srctype}' (choose from {msg})\n"
-        for msg in [
-            # Python 3.12.8/3.13.1+
-            ", ".join(project_main.SUPPORTED_COLLECTORS),
-            # Python < 3.12.8/3.13.1
-            ", ".join(f"'{x}'" for x in project_main.SUPPORTED_COLLECTORS),
-        ]
+    expected_err_msgs = invalid_choice_messages(
+        srctype,
+        choices=project_main.SUPPORTED_COLLECTORS,
     )
     captured = capsys.readouterr()
     assert not captured.out
@@ -1719,3 +1745,88 @@ def test_deps_cli_delete_depsconfig(mock_deps_command):
 
     project_main.main(deps_args)
     mock_deps_command.assert_called_once_with(*r_args, **r_kwargs)
+
+
+def test_completion_cli(mock_completion_command):
+    """Run completion with 'bash' argument"""
+    shell = "bash"
+    completion_args = ["completion", shell]
+    project_main.main(completion_args)
+    b_args = (shell,)
+    b_kwargs: dict[str, Any] = {}
+    mock_completion_command.assert_called_once_with(*b_args, **b_kwargs)
+
+
+def test_completion_unsupported_shell(capsys):
+    """Run completion with unsupported shell"""
+    shell = "zsh"
+    completion_args = ["completion", shell]
+    with pytest.raises(SystemExit) as exc:
+        project_main.main(completion_args, prog="pyproject-installer")
+    assert exc.value.code == ExitCodes.WRONG_USAGE
+
+    expected_err_msgs = invalid_choice_messages(
+        shell,
+        choices=project_main.SUPPORTED_SHELLS,
+    )
+    captured = capsys.readouterr()
+    assert not captured.out
+    assert any(True for msg in expected_err_msgs if msg in captured.err)
+
+
+def test_completion_cli_help(capsys):
+    """Run completion --help
+
+    - check msg and exit code
+    """
+    completion_args = ["completion", "--help"]
+
+    with pytest.raises(SystemExit) as exc:
+        project_main.main(completion_args)
+
+    assert exc.value.code == ExitCodes.OK
+
+    captured = capsys.readouterr()
+    assert not captured.err
+    expected_msg = "usage: python -m pyproject_installer completion "
+    assert expected_msg in captured.out
+
+
+def test_cli_entry(mock_main, mock_run_autocomplete, monkeypatch, mocker):
+    """
+    Run cli_entry in non-completion mode.
+
+    Expected results:
+    - run_autocomplete is not called
+    - main is called
+    """
+    monkeypatch.delenv("_PYPROJECT_INSTALLER_COMPLETE", raising=False)
+    main_args = ["any"]
+    mocker.patch.object(project_main.sys, "argv", ["any-prog", *main_args])
+    project_main.cli_entry()
+    b_args = main_args
+    b_kwargs = {"prog": "pyproject-installer"}
+    mock_run_autocomplete.assert_not_called()
+    mock_main.assert_called_once_with(b_args, **b_kwargs)
+
+
+def test_cli_entry_run_completion(
+    mock_main,
+    mock_run_autocomplete,
+    monkeypatch,
+    mocker,
+):
+    """
+    Run cli_entry in completion mode.
+
+    Expected results:
+    - run_autocomplete is called
+    - main is not called
+    """
+    monkeypatch.setenv("_PYPROJECT_INSTALLER_COMPLETE", "1")
+    main_args = ["any"]
+    mocker.patch.object(project_main.sys, "argv", ["any-prog", *main_args])
+    with pytest.raises(SystemExit):
+        project_main.cli_entry()
+    mock_run_autocomplete.assert_called_once()
+    mock_main.assert_not_called()


### PR DESCRIPTION
`pyproject-installer completion bash` emits a pip-style wrapper that calls back into Python at TAB time. The runtime dispatcher walks the live argparse tree, so completion cannot drift from the CLI.

Path candidates are driven by `action.metavar` (DIR / FILE / PATH); a CI test enforces every type=Path action declares one. Mutually- exclusive group members suppress each other once any is on the line. A bare `--` ends option parsing per argparse semantics.

Prerequisite: the self-hosted backend learns to emit dist-info/entry_points.txt from PEP 621 [project.scripts], and a pyproject-installer console script is registered.

Fixes: https://github.com/stanislavlevin/pyproject_installer/issues/153

## Summary by Sourcery

Add a bash-based CLI completion system and console entry point for pyproject-installer, driven by the live argparse parser and supported by backend entry point packaging.

New Features:
- Introduce a completion subcommand and bash wrapper emitter for pyproject-installer, enabling tab completion for commands, options, and path-like arguments.
- Add an autocomplete runtime that inspects the argparse parser at TAB time to compute context-aware completion candidates.
- Expose a pyproject-installer console script entry via PEP 621 [project.scripts] and wire cli_entry as its entry point.

Enhancements:
- Extend the custom build backend to emit dist-info/entry_points.txt from PEP 621 [project.scripts].
- Annotate Path-typed CLI arguments with DIR/FILE metavars to drive path-aware completion.
- Add a guard test ensuring all Path-typed CLI arguments declare appropriate path-like metavars to keep completion accurate.

Documentation:
- Document bash completion usage, including one-shot installation and eval-on-startup patterns, and add a detailed design document describing the completion architecture.

Tests:
- Add unit tests for completion CLI behavior, autocomplete candidate computation, bash script emission and sourceability, environment-variable-driven runtime behavior, and path-metavar invariants.
- Refactor invalid choice error expectation into a reusable helper to support completion-related tests.