### PR TITLE
feat(deps): add sync --verify-ignore-version option

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,14 @@ Sync stored requirements to configured sources.
 >
 > *Example:* `python -m pyproject_installer deps sync --verify build --verify-exclude 'foo.*'`
 
+> **`--verify-ignore-version`**
+>
+> Exclude from diff requirements that differ only in their version specifier, i.e. a requirement with the same PEP 503-normalized name, extras, marker and url is present on both sides of the diff. A requirement that was genuinely added or removed (or whose extras/marker/url changed) still appears in the diff and fails verification. Useful in downstream packaging to avoid failing on upstream upper-bound bumps such as `setuptools<81` -> `setuptools<82`. Requires `--verify`.
+>
+> *Default:* disabled
+>
+> *Example:* `python -m pyproject_installer deps sync --verify build --verify-ignore-version`
+
 See `python -m pyproject_installer deps sync --help` for full options.
 
 #### eval

--- a/docs/designs/verify_ignore_version_option.md
+++ b/docs/designs/verify_ignore_version_option.md
@@ -1,0 +1,118 @@
+## Abstract
+This RFE proposes a new opt-in `deps sync` option
+`--verify-ignore-version` that excludes from the verify diff any
+dependency whose only change is its version specifier. Intended for
+downstream packagers - primarily RPM - who run `deps sync --verify`
+as a drift gate and don't want it to fail (and force a re-sync
+commit) every time an upstream project tightens a version bound,
+such as `setuptools<81` -> `setuptools<82`.
+
+## Motivation
+`deps sync --verify` re-collects each source's requirements,
+compares them with the stored set, and - if anything differs -
+prints a `new_deps`/`extra_deps` diff and exits with
+`SYNC_VERIFY_ERROR` (4). A pure version-bound change shows up as
+the same distribution on both sides of that diff:
+
+```
+"setuptools<81,>=78.1.1"   stored    -> extra_deps
+"setuptools<82,>=78.1.1"   collected -> new_deps
+```
+
+For RPM packaging those versioned upper bounds are usually
+irrelevant - the distro ships its own setuptools - yet every such
+bump fails the gate, forcing the maintainer to re-sync and commit a
+`pyproject_deps.json` change that carries no packaging-relevant
+information. Across many packages this is constant diff noise.
+
+The existing `--verify-exclude <regex>` already drops chosen
+distributions from the diff, but it requires enumerating names up
+front and it hides a dependency entirely - including its genuine
+addition or removal. Version bumps happen to *any* dependency and
+can't be predicted, and the maintainer still wants to learn about
+real add/remove events. A dedicated option that targets only the
+"version moved, nothing else" case is the right tool.
+
+The option is opt-in because the default behaviour (fail on any
+difference) must stay unchanged for callers who rely on it.
+
+## Specification
+
+### User-facing contract
+- `--verify-ignore-version` is declared on the `deps sync`
+  subparser only, `action="store_true"`, default off.
+- Requires `--verify`. Used without it, CLI validation fails with
+  `--verify-ignore-version option must be used with --verify` and
+  exit code `WRONG_USAGE` (2), mirroring `--verify-exclude`.
+- Programmatic API: `DepsSourcesConfig.sync(...,
+  verify_ignore_version=False)`. Passing it without `verify=True`
+  raises `ValueError("verify_ignore_version must be used with
+  verify")`.
+- Composes with `--verify-exclude`: both filters apply to the diff.
+
+### What counts as a version-only change
+A dependency is version-only when the stored and collected
+requirements are equal in every PEP 508 field except the version
+specifier - i.e. same PEP 503-normalized name, extras, environment
+marker and url. Such a dependency lands on *both* sides of the diff
+(in `new_deps` from the collected side and `extra_deps` from the
+stored side); the intersection of the two sides, compared without
+specifiers, is exactly the set of version-only changes.
+
+A dependency that is genuinely added or removed appears on only one
+side and is kept. A change to extras, marker or url - even
+alongside a version change - makes the two requirements differ in a
+non-version field, so they no longer match and both are kept.
+Gaining or losing a specifier where the rest is unchanged (e.g.
+`foo` -> `foo>=1`) is version-only.
+
+### Behaviour
+With `--verify --verify-ignore-version`:
+
+- version-only changes are removed from the printed
+  `new_deps`/`extra_deps` diff;
+- if, after that removal (and any `--verify-exclude` removal), no
+  differences remain, the command succeeds (exit 0) instead of
+  raising `SYNC_VERIFY_ERROR`;
+- genuine additions/removals and extras/marker/url changes still
+  appear in the diff and still fail.
+
+Like `--verify` and `--verify-exclude`, the option does **not**
+change the on-disk write: each out-of-sync source's stored `deps`
+is still rewritten to the freshly collected set, including the new
+version bounds. The option governs the diff and the pass/fail
+decision only, not what is persisted.
+
+## Example
+
+```
+# Drift gate that tolerates upstream version-bound bumps.
+python -m pyproject_installer deps sync --verify \
+    --verify-ignore-version build
+```
+
+Given a `build` source stored as `setuptools<81,>=78.1.1` whose
+project now declares `setuptools<82,>=78.1.1`:
+
+- `deps sync --verify build` prints
+
+  ```json
+  {
+    "build": {
+      "extra_deps": [
+        "setuptools<81,>=78.1.1"
+      ],
+      "new_deps": [
+        "setuptools<82,>=78.1.1"
+      ]
+    }
+  }
+  ```
+
+  and exits 4;
+- `deps sync --verify --verify-ignore-version build` prints nothing
+  and exits 0.
+
+If the project instead *added* `tomli>=2`, that dependency still
+appears in `new_deps` and the command still exits 4, even with
+`--verify-ignore-version`.

--- a/src/pyproject_installer/__main__.py
+++ b/src/pyproject_installer/__main__.py
@@ -87,6 +87,11 @@ def deps(
         if getattr(args, "verify_excludes", []) and not args.verify:
             parser.error("--verify-exclude option must be used with --verify")
 
+        if getattr(args, "verify_ignore_version", False) and not args.verify:
+            parser.error(
+                "--verify-ignore-version option must be used with --verify",
+            )
+
         kwargs = {x: getattr(args, x) for x in args.main_args}
         try:
             deps_command(action_name, depsconfig, **kwargs)
@@ -317,6 +322,20 @@ def deps_subparsers(parser: argparse.ArgumentParser) -> None:
         help=(
             "Regex patterns, exclude from diff requirements PEP503-normalized "
             " names of those match one of the patterns (default: []). "
+            "Requires --verify"
+        ),
+    )
+
+    destname = "verify_ignore_version"
+    add_deps_argument(
+        subparser_sync,
+        destname,
+        "--verify-ignore-version",
+        dest=destname,
+        action="store_true",
+        help=(
+            "Exclude from diff requirements that differ only in their version "
+            "specifier (same PEP503-normalized name, extras, marker and url). "
             "Requires --verify"
         ),
     )

--- a/src/pyproject_installer/deps_cmd/deps_config.py
+++ b/src/pyproject_installer/deps_cmd/deps_config.py
@@ -8,7 +8,7 @@ from string import Template
 from typing import Any, TypedDict
 
 from ..errors import DepsSourcesConfigError, DepsUnsyncedError
-from ..lib import is_pep508_requirement, requirements
+from ..lib import is_pep508_requirement, requirements, specifiers
 from ..lib.normalization import pep503_normalized_name
 from .collectors import get_collector
 from .collectors.collector import Collector
@@ -209,6 +209,7 @@ class DepsSourcesConfig:
         srcnames: tuple[str, ...] = (),
         verify: bool = False,
         verify_excludes: tuple[str, ...] = (),
+        verify_ignore_version: bool = False,
     ) -> None:
         """Sync sources
 
@@ -217,9 +218,17 @@ class DepsSourcesConfig:
 
         verify_excludes: filter out dependencies from diff output
         normalized names of those match given regexes (requires verify=True).
+
+        verify_ignore_version: filter out from diff output dependencies that
+        differ only in their version specifier, i.e. a dependency with the same
+        normalized name, extras, marker and url is present on both sides of the
+        diff (requires verify=True).
         """
         if verify_excludes and not verify:
             raise ValueError("verify_excludes must be used with verify")
+
+        if verify_ignore_version and not verify:
+            raise ValueError("verify_ignore_version must be used with verify")
 
         diff: dict[str, dict[str, list[str]]] = {}
         verify_excludes_regs = {re.compile(x) for x in verify_excludes}
@@ -228,6 +237,19 @@ class DepsSourcesConfig:
             """filter diff output"""
             req_name = pep503_normalized_name(req.name)
             return not any(reg.match(req_name) for reg in verify_excludes_regs)
+
+        def version_less_req(
+            req: requirements.Requirement,
+        ) -> requirements.Requirement:
+            """New requirement equal to req but without its version specifier
+
+            Lets two requirements that differ only in their specifier compare
+            and hash equal through Requirement's own __eq__/__hash__, instead of
+            rebuilding their identity from hand-picked fields.
+            """
+            versionless = requirements.Requirement(str(req))
+            versionless.specifier = specifiers.SpecifierSet()
+            return versionless
 
         for srcname, source in self.iter_sources(srcnames):
             synced_deps = set(
@@ -252,13 +274,38 @@ class DepsSourcesConfig:
             if not verify:
                 continue
 
+            new_deps = synced_deps - stored_deps
+            extra_deps = stored_deps - synced_deps
+
+            if verify_ignore_version:
+                # Reuse one version-less form per requirement instead of
+                # reparsing it for every membership test below.
+                versionless = {
+                    req: version_less_req(req) for req in new_deps | extra_deps
+                }
+                # A version-less form on both sides of the diff means the dep
+                # was both added and removed, so only its version changed; the
+                # originals with such a form are dropped. A form on one side is
+                # a genuine add or removal and is kept.
+                both_sides = {versionless[req] for req in new_deps} & {
+                    versionless[req] for req in extra_deps
+                }
+                version_changed_deps = {
+                    req for req, vl in versionless.items() if vl in both_sides
+                }
+            else:
+                version_changed_deps = set()
+
             for field_name, diff_deps in (
-                ("new_deps", synced_deps - stored_deps),
-                ("extra_deps", stored_deps - synced_deps),
+                ("new_deps", new_deps),
+                ("extra_deps", extra_deps),
             ):
-                filtered_diff_deps = set(
-                    filter(filter_verify_excludes, diff_deps),
-                )
+                filtered_diff_deps = {
+                    req
+                    for req in diff_deps
+                    if filter_verify_excludes(req)
+                    and req not in version_changed_deps
+                }
 
                 if not filtered_diff_deps:
                     continue

--- a/tests/unit/test_deps/test_deps_config.py
+++ b/tests/unit/test_deps/test_deps_config.py
@@ -713,6 +713,223 @@ def test_config_sync_verify_exclude_without_verify(depsconfig, capsys):
     assert not captured.out
 
 
+@pytest.mark.parametrize(
+    "old_reqs,new_reqs",
+    (
+        # only the version specifier differs
+        (["foo>=1"], ["foo>=2"]),
+        (["foo<81,>=78.1.1"], ["foo<82,>=78.1.1"]),
+        # extras and markers preserved, only version changes
+        (["foo[a,b]>=1"], ["foo[a,b]>=2"]),
+        (
+            ['foo>=1; python_version < "3.11"'],
+            ['foo>=2; python_version < "3.11"'],
+        ),
+        # several deps, all version-only
+        (["foo>=1", "bar==1"], ["foo>=2", "bar==2"]),
+        # gaining a specifier where there was none is still version-only
+        (["foo"], ["foo>=1"]),
+    ),
+)
+def test_config_sync_verify_ignore_version_unchanged(
+    old_reqs,
+    new_reqs,
+    depsconfig,
+    mock_collector,
+    capsys,
+):
+    """Sync version-only changed source with verify and ignore-version
+
+    Version-only changes don't appear in the diff and don't fail, but the
+    config is still rewritten to the synced deps.
+    """
+
+    action = "sync"
+    srcname = "src_foo"
+
+    input_conf = {
+        "sources": {
+            srcname: {
+                "srctype": "mock_collector",
+                "deps": old_reqs,
+            },
+        },
+    }
+    depsconfig_path = depsconfig(json.dumps(input_conf))
+
+    mock_collector(new_reqs)
+
+    deps_command(
+        action,
+        depsconfig_path,
+        srcnames=[],
+        verify=True,
+        verify_ignore_version=True,
+    )
+
+    expected_conf = deepcopy(input_conf)
+    expected_conf["sources"][srcname]["deps"] = sorted(new_reqs)
+
+    actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))
+    assert actual_conf == expected_conf
+
+    captured = capsys.readouterr()
+    assert not captured.err
+    assert not captured.out
+
+
+@pytest.mark.parametrize(
+    "data",
+    # original reqs, updated reqs, expected diff
+    (
+        # version-only foo suppressed, genuinely added dep surfaces
+        (
+            ["foo>=1"],
+            ["foo>=2", "newdep>=1"],
+            {"new_deps": ["newdep>=1"]},
+        ),
+        # version-only foo suppressed, genuinely removed dep surfaces
+        (
+            ["foo>=1", "gone==1"],
+            ["foo>=2"],
+            {"extra_deps": ["gone==1"]},
+        ),
+        # a change of extras is a real change, not a version change
+        (
+            ["foo[a]>=1"],
+            ["foo[a,b]>=2"],
+            {"extra_deps": ["foo[a]>=1"], "new_deps": ["foo[a,b]>=2"]},
+        ),
+        # a change of marker is a real change, not a version change
+        (
+            ['foo>=1; python_version < "3.11"'],
+            ['foo>=2; python_version < "3.12"'],
+            {
+                "extra_deps": ['foo>=1; python_version < "3.11"'],
+                "new_deps": ['foo>=2; python_version < "3.12"'],
+            },
+        ),
+    ),
+)
+def test_config_sync_verify_ignore_version_changed(
+    data,
+    depsconfig,
+    mock_collector,
+    capsys,
+):
+    """Sync source with verify and ignore-version, real changes still fail"""
+
+    action = "sync"
+    old_reqs, new_reqs, diff = data
+    srcname = "src_foo"
+
+    input_conf = {
+        "sources": {
+            srcname: {
+                "srctype": "mock_collector",
+                "deps": old_reqs,
+            },
+        },
+    }
+    depsconfig_path = depsconfig(json.dumps(input_conf))
+
+    mock_collector(new_reqs)
+
+    with pytest.raises(DepsUnsyncedError):
+        deps_command(
+            action,
+            depsconfig_path,
+            srcnames=[],
+            verify=True,
+            verify_ignore_version=True,
+        )
+
+    expected_conf = deepcopy(input_conf)
+    expected_conf["sources"][srcname]["deps"] = sorted(new_reqs)
+
+    actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))
+    assert actual_conf == expected_conf
+
+    expected_out = json.dumps({srcname: diff}, indent=2) + "\n"
+
+    captured = capsys.readouterr()
+    assert not captured.err
+    assert captured.out == expected_out
+
+
+def test_config_sync_verify_ignore_version_with_exclude(
+    depsconfig,
+    mock_collector,
+    capsys,
+):
+    """ignore-version and exclude filters compose"""
+
+    action = "sync"
+    srcname = "src_foo"
+
+    # foo: version-only (ignored), bar: removed but excluded, baz: added
+    old_reqs = ["foo>=1", "bar==1"]
+    new_reqs = ["foo>=2", "baz>=1"]
+
+    input_conf = {
+        "sources": {
+            srcname: {
+                "srctype": "mock_collector",
+                "deps": old_reqs,
+            },
+        },
+    }
+    depsconfig_path = depsconfig(json.dumps(input_conf))
+
+    mock_collector(new_reqs)
+
+    with pytest.raises(DepsUnsyncedError):
+        deps_command(
+            action,
+            depsconfig_path,
+            srcnames=[],
+            verify=True,
+            verify_ignore_version=True,
+            verify_excludes=["bar.*"],
+        )
+
+    expected_conf = deepcopy(input_conf)
+    expected_conf["sources"][srcname]["deps"] = sorted(new_reqs)
+
+    actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))
+    assert actual_conf == expected_conf
+
+    diff = {srcname: {"new_deps": ["baz>=1"]}}
+    expected_out = json.dumps(diff, indent=2) + "\n"
+
+    captured = capsys.readouterr()
+    assert not captured.err
+    assert captured.out == expected_out
+
+
+def test_config_sync_verify_ignore_version_without_verify(depsconfig, capsys):
+    """Sync with ignore-version and without verify"""
+
+    action = "sync"
+
+    input_conf = {"sources": {"foo": {"srctype": "metadata"}}}
+    depsconfig_path = depsconfig(json.dumps(input_conf))
+
+    expected_err = re.escape("verify_ignore_version must be used with verify")
+    expected_err = f"^{expected_err}"
+    with pytest.raises(ValueError, match=expected_err):
+        deps_command(
+            action,
+            depsconfig_path,
+            srcnames=[],
+            verify_ignore_version=True,
+        )
+
+    captured = capsys.readouterr()
+    assert not captured.err
+    assert not captured.out
+
+
 @pytest.mark.parametrize("select_data", NONEXISTENT_SOURCE_DATA)
 def test_config_sync_nonexistent_source(select_data, depsconfig, capsys):
     """Sync nonexistent source"""

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -924,7 +924,12 @@ def test_deps_cli_sync_default(mock_deps_command):
     deps_args = ["deps", action]
 
     r_args = (action, Path(depsconfig))
-    r_kwargs = {"srcnames": [], "verify": False, "verify_excludes": []}
+    r_kwargs = {
+        "srcnames": [],
+        "verify": False,
+        "verify_excludes": [],
+        "verify_ignore_version": False,
+    }
 
     project_main.main(deps_args)
     mock_deps_command.assert_called_once_with(*r_args, **r_kwargs)
@@ -941,7 +946,12 @@ def test_deps_cli_sync_depsconfig(mock_deps_command):
     deps_args = ["deps", "--depsconfig", depsconfig, action]
 
     r_args = (action, Path(depsconfig))
-    r_kwargs = {"srcnames": [], "verify": False, "verify_excludes": []}
+    r_kwargs = {
+        "srcnames": [],
+        "verify": False,
+        "verify_excludes": [],
+        "verify_ignore_version": False,
+    }
 
     project_main.main(deps_args)
     mock_deps_command.assert_called_once_with(*r_args, **r_kwargs)
@@ -960,7 +970,12 @@ def test_deps_cli_sync_selected(mock_deps_command, srcnames):
     deps_args.extend(srcnames)
 
     r_args = (action, Path(depsconfig))
-    r_kwargs = {"srcnames": srcnames, "verify": False, "verify_excludes": []}
+    r_kwargs = {
+        "srcnames": srcnames,
+        "verify": False,
+        "verify_excludes": [],
+        "verify_ignore_version": False,
+    }
 
     project_main.main(deps_args)
     mock_deps_command.assert_called_once_with(*r_args, **r_kwargs)
@@ -1300,7 +1315,12 @@ def test_deps_cli_sync_verify(mock_deps_command):
     deps_args = ["deps", action, "--verify"]
 
     r_args = (action, Path(depsconfig))
-    r_kwargs = {"srcnames": [], "verify": True, "verify_excludes": []}
+    r_kwargs = {
+        "srcnames": [],
+        "verify": True,
+        "verify_excludes": [],
+        "verify_ignore_version": False,
+    }
 
     project_main.main(deps_args)
     mock_deps_command.assert_called_once_with(*r_args, **r_kwargs)
@@ -1334,7 +1354,12 @@ def test_deps_cli_sync_verify_excludes(excludes, mock_deps_command):
     deps_args.extend(excludes)
 
     r_args = (action, Path(depsconfig))
-    r_kwargs = {"srcnames": [], "verify": True, "verify_excludes": excludes}
+    r_kwargs = {
+        "srcnames": [],
+        "verify": True,
+        "verify_excludes": excludes,
+        "verify_ignore_version": False,
+    }
 
     project_main.main(deps_args)
     mock_deps_command.assert_called_once_with(*r_args, **r_kwargs)
@@ -1358,6 +1383,49 @@ def test_deps_cli_sync_verify_excludes_without_verify(capsys):
     captured = capsys.readouterr()
     assert not captured.out
     expected_msg = "--verify-exclude option must be used with --verify"
+    assert expected_msg in captured.err
+
+
+def test_deps_cli_sync_verify_ignore_version(mock_deps_command):
+    """Run deps sync with verify and ignore-version
+
+    - mock deps_command
+    - check args
+    """
+    action = "sync"
+    depsconfig = Path.cwd() / project_main.DEFAULT_CONFIG_NAME
+    deps_args = ["deps", action, "--verify", "--verify-ignore-version"]
+
+    r_args = (action, depsconfig)
+    r_kwargs = {
+        "srcnames": [],
+        "verify": True,
+        "verify_excludes": [],
+        "verify_ignore_version": True,
+    }
+
+    project_main.main(deps_args)
+    mock_deps_command.assert_called_once_with(*r_args, **r_kwargs)
+
+
+@pytest.mark.usefixtures("mock_deps_command")
+def test_deps_cli_sync_verify_ignore_version_without_verify(capsys):
+    """Run deps sync with ignore-version and without verify
+
+    - mock deps_command
+    - check error
+    """
+    action = "sync"
+    deps_args = ["deps", action, "--verify-ignore-version"]
+
+    with pytest.raises(SystemExit) as exc:
+        project_main.main(deps_args)
+
+    assert exc.value.code == ExitCodes.WRONG_USAGE
+
+    captured = capsys.readouterr()
+    assert not captured.out
+    expected_msg = "--verify-ignore-version option must be used with --verify"
     assert expected_msg in captured.err
 
 


### PR DESCRIPTION
`deps sync --verify` fails whenever stored requirements differ from the configured sources, including when only a version specifier changed (e.g. `setuptools<81` -> `setuptools<82`). In downstream packaging that produces noise on every upstream upper-bound bump.

Add `--verify-ignore-version` (requires `--verify`) which excludes from the diff requirements that differ only in their version specifier, i.e. a requirement with the same PEP503-normalized name, extras, marker and url is present on both sides of the diff. Genuinely added or removed dependencies (or changes to extras/marker/url) still appear in the diff and fail verification.

Mirrors `--verify-exclude`: it only affects the printed diff and the pass/fail decision; the config is still rewritten to the synced deps.

Fixes:https://github.com/stanislavlevin/pyproject_installer/issues/155

## Summary by Sourcery

Add an opt-in deps sync verification mode that ignores version-only requirement changes while still detecting real dependency drift.

New Features:
- Introduce a --verify-ignore-version option for deps sync that suppresses diff entries where only the version specifier changed, while still rewriting stored dependencies.
- Expose verify_ignore_version through both the CLI and the DepsSourcesConfig.sync API, enforcing that it can only be used together with verification.

Bug Fixes:
- Prevent version-only requirement changes from causing spurious verification failures in downstream packaging workflows relying on deps sync --verify.

Enhancements:
- Ensure the new verify-ignore-version filter composes correctly with existing verify-exclude patterns when computing dependency diffs.
- Document the semantics and use cases of the verify-ignore-version option in the README and a dedicated design document.

Documentation:
- Document the new --verify-ignore-version option and its behavior in the README and add a detailed design document explaining its motivation and semantics.

Tests:
- Add unit tests covering verify_ignore_version behavior in sync logic, including unchanged version-only diffs, real changes, composition with verify_exclude, and misuse without verify.
- Extend CLI tests to cover the new --verify-ignore-version flag, its interaction with --verify, default argument wiring, and error handling when used incorrectly.