### PR TITLE
feat(deps): add `add --reconfigure` and `--sync` to cut per-source spawns

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,22 @@ Configure source of Python dependencies. Supported sources: standardized formats
 >
 > *Default:* `[]`
 
+> **`--reconfigure`**
+>
+> Reconfigure an already-configured source instead of failing on a duplicate name: keep it when the source type and args are unchanged (exit 0), or replace it (dropping its stored deps) when they differ. Without this flag, adding an already-configured name is an error.
+>
+> *Default:* disabled
+>
+> *Example:* `python -m pyproject_installer deps add --reconfigure runtime metadata`
+
+> **`--sync`**
+>
+> After a successful add (newly added, kept, or replaced), sync the source in the same process. Accepts the same verify options as [`deps sync`](#sync) (`--verify`, `--verify-exclude`, `--verify-ignore-version`), each of which requires `--sync`. This lets a single `add` call replace the downstream `show || add` followed by `sync` sequence. Because `--verify-exclude` takes one or more values, give the source name and type *before* the verify options (or use the `--verify-exclude=PATTERN` form); otherwise they are folded into the exclude list.
+>
+> *Default:* disabled
+>
+> *Example:* `python -m pyproject_installer deps add build_pep517 pep517 --sync --verify --verify-exclude 'wheel$'`
+
 Examples:
 
 ```console

--- a/docs/designs/deps_add_reconfigure_and_sync.md
+++ b/docs/designs/deps_add_reconfigure_and_sync.md
@@ -1,0 +1,104 @@
+## Abstract
+This RFE proposes two opt-in `deps add` options that let a single
+`add` call replace the `show <name> || add <name> <type> <args>`
+followed by `sync <name> ...` sequence a downstream packager runs
+per source:
+
+- `--reconfigure` makes `add` idempotent -- keep the
+  source when its type and args are unchanged, replace it when they
+  differ -- instead of erroring on an existing name.
+- `--sync` runs a sync on the source in the same process after any
+  successful `add` (newly added, kept unchanged, or replaced),
+  reusing the existing `sync` verify options.
+
+## Motivation
+Downstream packaging (RPM) configures every dependency source in a
+build's `%prep` with the same two steps:
+
+```
+show <name> 1>/dev/null 2>&1 || add <name> <type> <args>
+sync <name> --verify [--verify-exclude ...]
+```
+
+For a typical project that is `pep518`, `pep517`, `metadata`, and
+one or more check sources -- two to three `python -m
+pyproject_installer` process spawns per source, where interpreter
+startup dominates the cost. Two facts force the extra spawns:
+
+- `add` raises when the source already exists, so the `show ||`
+  guard is needed every build even though a committed
+  `pyproject_deps.json` already lists the source;
+- `add` cannot sync, so a separate `sync` invocation is needed.
+
+Folding both into `add` cuts the per-source cost to one process and
+removes the guard. The options are opt-in; default `add` behaviour
+is unchanged.
+
+## Specification
+
+### `--reconfigure`
+Declared on the `deps add` subparser, `action="store_true"`,
+default off.
+
+- source not configured -> add it (current behaviour);
+- configured with the **same** `type` and `args` -> no-op, exit 0
+  (this is the `show ||` case);
+- configured with a **different** `type` or `args` -> remove the
+  source together with its stored `deps`, then add the new one.
+
+Without the flag, adding an already-configured name still fails
+with `Source <name> already exists`, unchanged.
+
+Programmatic API: `DepsSourcesConfig.add(..., reconfigure=False,
+sync=False, verify=False, verify_excludes=(),
+verify_ignore_version=False)`.
+
+### `--sync`
+Declared on `deps add`, `action="store_true"`, default off. When set,
+`add()` syncs `name` itself after configuring it, in the same process --
+the sync lives in the library method, not a separate CLI step.
+Independent of `--reconfigure`: `add --sync name type args` (no
+`--reconfigure`) adds a new source then syncs it; with `--reconfigure`
+it also syncs after a kept or replaced source. Either way, sync runs
+only when the add succeeded.
+
+`--sync` and the sync options -- `--verify`, `--verify-exclude`,
+`--verify-ignore-version` -- are `add()` parameters. They are declared
+on the `add` subparser with the same `add_sync_options` helper (built
+on `add_deps_argument`) that `sync` uses, so they are forwarded through
+`main_args` to `add()`, which passes the verify options on to its own
+`sync()` call. Because `--verify-exclude` takes one or more values
+(`nargs="+"`), the source `name` and `type` must be given **before** the
+verify options (or use the `--verify-exclude=PATTERN` form); otherwise
+argparse greedily folds the positionals into the exclude list.
+
+### Usage validation
+Mirrors the existing checks, exit `WRONG_USAGE` (2):
+
+- the sync/verify options require `--sync`;
+- `--verify-exclude` and `--verify-ignore-version` require `--verify`.
+
+### Behaviour
+`add --sync --verify` performs add-or-reconfigure then sync in one
+process. The sync step runs **only if the add/reconfigure part
+succeeded**; a failed add does not proceed to sync. The verify
+outcome is delegated to the existing sync, so a drift exits
+`SYNC_VERIFY_ERROR` (4). A source freshly added (or
+replaced, hence with no stored deps) drifts on its first
+`--verify`. With neither option set, `add` is exactly as today.
+
+## Example
+
+```
+# Configure-or-reconfigure a source and verify it, in one call.
+# Note: name/type come before --verify-exclude (nargs="+").
+python -m pyproject_installer deps add pep517 pep517 \
+    --reconfigure --sync --verify --verify-exclude 'wheel$'
+```
+
+- pep517 not configured -> added, then synced; new source -> drift ->
+  exit 4.
+- pep517 already configured as `pep517 pep517` -> kept; sync
+  re-collects and `--verify` passes if its deps are unchanged.
+- pep517 configured with different args -> replaced, then synced ->
+  drift -> exit 4.

--- a/src/pyproject_installer/__main__.py
+++ b/src/pyproject_installer/__main__.py
@@ -84,6 +84,15 @@ def deps(
         ):
             parser.error("depformatextra option must be used with depformat")
 
+        if (
+            hasattr(args, "sync")
+            and not args.sync
+            and any(
+                (args.verify, args.verify_excludes, args.verify_ignore_version),
+            )
+        ):
+            parser.error("--verify options on add must be used with --sync")
+
         if getattr(args, "verify_excludes", []) and not args.verify:
             parser.error("--verify-exclude option must be used with --verify")
 
@@ -267,6 +276,54 @@ def deps_subparsers(parser: argparse.ArgumentParser) -> None:
         parser.set_defaults(main=deps(name))
         return parser
 
+    def add_sync_options(parser: argparse.ArgumentParser) -> None:
+        """Add the verify options shared by `sync` and `add`.
+
+        Registered in `main_args`, so they are forwarded to the action:
+        `sync()` directly, or `add()` (which passes them on to its own
+        sync when `--sync` is given).
+        """
+        destname = "verify"
+        add_deps_argument(
+            parser,
+            destname,
+            f"--{destname}",
+            action="store_true",
+            help=(
+                "Sync sources, but print diff and exits with code "
+                f"{ExitCodes.SYNC_VERIFY_ERROR} if the sources were unsynced"
+            ),
+        )
+
+        destname = "verify_excludes"
+        add_deps_argument(
+            parser,
+            destname,
+            "--verify-exclude",
+            dest=destname,
+            nargs="+",
+            default=[],
+            help=(
+                "Regex patterns; exclude from diff requirements whose "
+                "PEP503-normalized names match one of the patterns "
+                "(default: []). Requires --verify"
+            ),
+        )
+
+        destname = "verify_ignore_version"
+        add_deps_argument(
+            parser,
+            destname,
+            "--verify-ignore-version",
+            dest=destname,
+            action="store_true",
+            help=(
+                "Exclude from diff requirements that differ only in their "
+                "version specifier (same PEP503-normalized name, extras, "
+                "marker and url). Requires --verify"
+            ),
+        )
+
     # show
     subparser_show = add_deps_parser(
         subparsers,
@@ -299,46 +356,7 @@ def deps_subparsers(parser: argparse.ArgumentParser) -> None:
         nargs="*",
     )
 
-    destname = "verify"
-    add_deps_argument(
-        subparser_sync,
-        destname,
-        f"--{destname}",
-        help=(
-            "Sync sources, but print diff and exits with code "
-            f"{ExitCodes.SYNC_VERIFY_ERROR} if the sources were unsynced"
-        ),
-        action="store_true",
-    )
-
-    destname = "verify_excludes"
-    add_deps_argument(
-        subparser_sync,
-        destname,
-        "--verify-exclude",
-        dest=destname,
-        nargs="+",
-        default=[],
-        help=(
-            "Regex patterns, exclude from diff requirements PEP503-normalized "
-            " names of those match one of the patterns (default: []). "
-            "Requires --verify"
-        ),
-    )
-
-    destname = "verify_ignore_version"
-    add_deps_argument(
-        subparser_sync,
-        destname,
-        "--verify-ignore-version",
-        dest=destname,
-        action="store_true",
-        help=(
-            "Exclude from diff requirements that differ only in their version "
-            "specifier (same PEP503-normalized name, extras, marker and url). "
-            "Requires --verify"
-        ),
-    )
+    add_sync_options(subparser_sync)
 
     # eval
     subparser_eval = add_deps_parser(
@@ -445,6 +463,33 @@ def deps_subparsers(parser: argparse.ArgumentParser) -> None:
         nargs="*",
         help="specific configuration options for source (default: [])",
     )
+
+    destname = "reconfigure"
+    add_deps_argument(
+        subparser_add,
+        destname,
+        f"--{destname}",
+        action="store_true",
+        help=(
+            "Reconfigure an already-configured source: keep it when the type "
+            "and args are unchanged, replace it (dropping stored deps) when "
+            "they differ. Without this, an existing source is an error."
+        ),
+    )
+
+    destname = "sync"
+    add_deps_argument(
+        subparser_add,
+        destname,
+        f"--{destname}",
+        action="store_true",
+        help=(
+            "After configuring the source, sync it in the same process "
+            "(accepts the verify options below). Lets one add call replace "
+            "a separate sync."
+        ),
+    )
+    add_sync_options(subparser_add)
 
     # delete
     subparser_delete = add_deps_parser(

--- a/src/pyproject_installer/deps_cmd/deps_config.py
+++ b/src/pyproject_installer/deps_cmd/deps_config.py
@@ -150,19 +150,56 @@ class DepsSourcesConfig:
         srcname: str,
         srctype: str,
         srcargs: tuple[str, ...] = (),
+        *,
+        reconfigure: bool = False,
+        sync: bool = False,
+        verify: bool = False,
+        verify_excludes: tuple[str, ...] = (),
+        verify_ignore_version: bool = False,
     ) -> None:
+        """Configure a source of dependencies, optionally syncing it
+
+        reconfigure: if the source already exists, keep it when its type
+        and args are unchanged, or replace it (dropping its stored deps)
+        when they differ, instead of raising. Without it an existing
+        source raises ValueError.
+
+        sync: after configuring the source (newly added, kept or
+        replaced), sync it in the same process. The verify options
+        (verify, verify_excludes, verify_ignore_version) are forwarded to
+        sync() and only apply when sync=True.
+        """
         if not self.file.is_file():
             # allow new file
             self.set_default()
         srcargs = tuple(srcargs)
         self.validate_collector(srctype, srcargs)
 
+        keep_existing = False
         if srcname in self.sources:
-            raise ValueError(f"Source {srcname} already exists")
-        self.sources[srcname] = {"srctype": srctype}
-        if srcargs:
-            self.sources[srcname]["srcargs"] = srcargs
-        self.save()
+            if not reconfigure:
+                raise ValueError(f"Source {srcname} already exists")
+            if (
+                self.sources[srcname]["srctype"] == srctype
+                and tuple(self.sources[srcname].get("srcargs", ())) == srcargs
+            ):
+                keep_existing = True
+            else:
+                del self.sources[srcname]
+
+        if not keep_existing:
+            self.sources[srcname] = {"srctype": srctype}
+            if srcargs:
+                self.sources[srcname]["srcargs"] = srcargs
+            self.save()
+
+        if sync:
+            self.sync(
+                srcnames=(srcname,),
+                verify=verify,
+                verify_excludes=verify_excludes,
+                verify_ignore_version=verify_ignore_version,
+            )
 
     def delete(self, srcname: str) -> None:
         if srcname not in self.sources:
@@ -216,8 +253,8 @@ class DepsSourcesConfig:
         verify: do sync of selected sources, but print the diff on
         stdout and raise DepsUnsyncedError if sources were unsynced before
 
-        verify_excludes: filter out dependencies from diff output
-        normalized names of those match given regexes (requires verify=True).
+        verify_excludes: filter out from diff output dependencies whose
+        normalized names match given regexes (requires verify=True).
 
         verify_ignore_version: filter out from diff output dependencies that
         differ only in their version specifier, i.e. a dependency with the same

--- a/tests/unit/test_deps/test_deps_config.py
+++ b/tests/unit/test_deps/test_deps_config.py
@@ -224,6 +224,222 @@ def test_config_add_srcargs(depsconfig_path):
     assert config_data == expected_data
 
 
+def test_config_add_reconfigure_new(depsconfig_path):
+    """reconfigure=True adds a not-yet-configured source (same as plain add)."""
+
+    action = "add"
+    srcname = "foo"
+    srctype = "metadata"
+
+    assert not depsconfig_path.exists()
+    deps_command(
+        action,
+        depsconfig_path,
+        srcname=srcname,
+        srctype=srctype,
+        reconfigure=True,
+    )
+    actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))
+    expected_conf = {"sources": {srcname: {"srctype": srctype}}}
+    assert actual_conf == expected_conf
+
+
+def test_config_add_reconfigure_same_keeps_deps(depsconfig):
+    """reconfigure with identical type+args is a no-op and keeps stored deps."""
+
+    action = "add"
+    srcname = "foo"
+    srctype = "pip_reqfile"
+    srcargs = ["r.txt"]
+
+    input_conf = {
+        "sources": {
+            srcname: {"srctype": srctype, "srcargs": srcargs, "deps": ["bar"]},
+        },
+    }
+    depsconfig_path = depsconfig(json.dumps(input_conf))
+
+    deps_command(
+        action,
+        depsconfig_path,
+        srcname=srcname,
+        srctype=srctype,
+        srcargs=srcargs,
+        reconfigure=True,
+    )
+    expected_conf = deepcopy(input_conf)
+    actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))
+    assert actual_conf == expected_conf
+
+
+def test_config_add_reconfigure_differ_args_drops_deps(depsconfig):
+    """reconfigure with different args replaces the source, drops its deps."""
+
+    action = "add"
+    srcname = "foo"
+    srctype = "pip_reqfile"
+    srcargs = ["other.txt"]
+
+    input_conf = {
+        "sources": {
+            srcname: {
+                "srctype": srctype,
+                "srcargs": ["r.txt"],
+                "deps": ["bar"],
+            },
+        },
+    }
+    depsconfig_path = depsconfig(json.dumps(input_conf))
+
+    deps_command(
+        action,
+        depsconfig_path,
+        srcname=srcname,
+        srctype=srctype,
+        srcargs=srcargs,
+        reconfigure=True,
+    )
+    expected_conf = deepcopy(input_conf)
+    expected_conf["sources"][srcname]["srcargs"] = srcargs
+    del expected_conf["sources"][srcname]["deps"]
+    actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))
+    assert actual_conf == expected_conf
+
+
+def test_config_add_reconfigure_differ_type_drops_deps(depsconfig):
+    """reconfigure with different type replaces the source, drops its deps."""
+
+    action = "add"
+    srcname = "foo"
+    srctype = "pip_reqfile"
+    srcargs = ["other.txt"]
+
+    input_conf = {
+        "sources": {
+            srcname: {
+                "srctype": "tox",
+                "srcargs": ["tox.ini", "testenv"],
+                "deps": ["bar"],
+            },
+        },
+    }
+    depsconfig_path = depsconfig(json.dumps(input_conf))
+
+    deps_command(
+        action,
+        depsconfig_path,
+        srcname=srcname,
+        srctype=srctype,
+        srcargs=srcargs,
+        reconfigure=True,
+    )
+    expected_conf = deepcopy(input_conf)
+    expected_conf["sources"][srcname]["srctype"] = srctype
+    expected_conf["sources"][srcname]["srcargs"] = srcargs
+    del expected_conf["sources"][srcname]["deps"]
+    actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))
+    assert actual_conf == expected_conf
+
+
+def test_config_add_sync(depsconfig_path, mock_collector):
+    """add(sync=True) configures the source then syncs it (collects deps)."""
+
+    action = "add"
+    srcname = "foo"
+    srctype = "mock_collector"
+    new_reqs = ["bar", "baz"]
+
+    mock_collector(new_reqs)
+    deps_command(
+        action,
+        depsconfig_path,
+        srcname=srcname,
+        srctype=srctype,
+        sync=True,
+    )
+    expected_conf = {
+        "sources": {srcname: {"srctype": srctype, "deps": new_reqs}},
+    }
+    actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))
+    assert actual_conf == expected_conf
+
+
+def test_config_add_reconfigure_keep_sync(depsconfig, mock_collector):
+    """reconfigure-keep with sync=True still syncs (no early return)."""
+
+    action = "add"
+    srcname = "foo"
+    srctype = "mock_collector"
+    old_reqs = ["old"]
+    new_reqs = ["new"]
+
+    input_conf = {
+        "sources": {srcname: {"srctype": srctype, "deps": old_reqs}},
+    }
+    depsconfig_path = depsconfig(json.dumps(input_conf))
+
+    mock_collector(new_reqs)
+    deps_command(
+        action,
+        depsconfig_path,
+        srcname=srcname,
+        srctype=srctype,
+        reconfigure=True,
+        sync=True,
+    )
+    expected_conf = deepcopy(input_conf)
+    expected_conf["sources"][srcname]["deps"] = new_reqs
+    actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))
+    assert actual_conf == expected_conf
+
+
+def test_config_add_sync_skipped_when_add_fails(depsconfig):
+    """add(sync=True) must not sync when the add itself fails."""
+
+    action = "add"
+    srcname = "foo"
+    srctype = "metadata"
+    old_reqs = ["bar"]
+
+    input_conf = {
+        "sources": {srcname: {"srctype": srctype, "deps": old_reqs}},
+    }
+    depsconfig_path = depsconfig(json.dumps(input_conf))
+
+    with pytest.raises(ValueError, match=rf"^Source {srcname} already exists"):
+        deps_command(
+            action,
+            depsconfig_path,
+            srcname=srcname,
+            srctype=srctype,
+            sync=True,
+        )
+
+    expected_conf = deepcopy(input_conf)
+    actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))
+    assert actual_conf == expected_conf
+
+
+def test_config_add_sync_verify_drift(depsconfig_path, mock_collector):
+    """add(sync=True, verify=True) raises DepsUnsyncedError on drift."""
+
+    action = "add"
+    srcname = "foo"
+    srctype = "mock_collector"
+    new_reqs = ["bar"]
+
+    mock_collector(new_reqs)
+    with pytest.raises(DepsUnsyncedError):
+        deps_command(
+            action,
+            depsconfig_path,
+            srcname=srcname,
+            srctype=srctype,
+            sync=True,
+            verify=True,
+        )
+
+
 def test_config_delete(depsconfig):
     """Delete source"""
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -103,6 +103,16 @@ def invalid_choice_messages(choice, *, choices):
     )
 
 
+DEFAULT_DEPS_ADD_CLI_KWARGS = {
+    "srcargs": [],
+    "reconfigure": False,
+    "sync": False,
+    "verify": False,
+    "verify_excludes": [],
+    "verify_ignore_version": False,
+}
+
+
 def test_version():
     result = subprocess.run(
         args=[sys.executable, "-m", "pyproject_installer", "--version"],
@@ -1676,11 +1686,11 @@ def test_deps_cli_add_default(mock_deps_command):
     deps_args = ["deps", action, srcname, srctype]
 
     r_args = (action, Path(depsconfig))
-    r_kwargs = {
-        "srcname": srcname,
-        "srctype": srctype,
-        "srcargs": [],
-    }
+    r_kwargs = dict(
+        DEFAULT_DEPS_ADD_CLI_KWARGS,
+        srcname=srcname,
+        srctype=srctype,
+    )
 
     project_main.main(deps_args)
     mock_deps_command.assert_called_once_with(*r_args, **r_kwargs)
@@ -1699,11 +1709,11 @@ def test_deps_cli_add_depsconfig(mock_deps_command):
     deps_args = ["deps", "--depsconfig", depsconfig, action, srcname, srctype]
 
     r_args = (action, Path(depsconfig))
-    r_kwargs = {
-        "srcname": srcname,
-        "srctype": srctype,
-        "srcargs": [],
-    }
+    r_kwargs = dict(
+        DEFAULT_DEPS_ADD_CLI_KWARGS,
+        srcname=srcname,
+        srctype=srctype,
+    )
 
     project_main.main(deps_args)
     mock_deps_command.assert_called_once_with(*r_args, **r_kwargs)
@@ -1749,14 +1759,181 @@ def test_deps_cli_add_sourceargs(srcargs, mock_deps_command):
     deps_args.extend(srcargs)
 
     r_args = (action, Path(depsconfig))
-    r_kwargs = {
-        "srcname": srcname,
-        "srctype": srctype,
-        "srcargs": srcargs,
-    }
+    r_kwargs = dict(
+        DEFAULT_DEPS_ADD_CLI_KWARGS,
+        srcname=srcname,
+        srctype=srctype,
+        srcargs=srcargs,
+    )
 
     project_main.main(deps_args)
     mock_deps_command.assert_called_once_with(*r_args, **r_kwargs)
+
+
+def test_deps_cli_add_reconfigure(mock_deps_command):
+    """Run deps add with reconfigure
+
+    - mock deps_command
+    - check args
+    """
+    action = "add"
+    depsconfig = Path.cwd() / project_main.DEFAULT_CONFIG_NAME
+    srcname = "foo"
+    srctype = "metadata"
+    deps_args = ["deps", action, "--reconfigure", srcname, srctype]
+
+    r_args = (action, Path(depsconfig))
+    r_kwargs = dict(
+        DEFAULT_DEPS_ADD_CLI_KWARGS,
+        srcname=srcname,
+        srctype=srctype,
+        reconfigure=True,
+    )
+
+    project_main.main(deps_args)
+    mock_deps_command.assert_called_once_with(*r_args, **r_kwargs)
+
+
+def test_deps_cli_add_sync(mock_deps_command):
+    """Run deps add with sync
+
+    - mock deps_command
+    - check args
+    """
+    action = "add"
+    depsconfig = Path.cwd() / project_main.DEFAULT_CONFIG_NAME
+    srcname = "foo"
+    srctype = "metadata"
+    deps_args = ["deps", action, "--sync", srcname, srctype]
+
+    r_args = (action, Path(depsconfig))
+    r_kwargs = dict(
+        DEFAULT_DEPS_ADD_CLI_KWARGS,
+        srcname=srcname,
+        srctype=srctype,
+        sync=True,
+    )
+
+    project_main.main(deps_args)
+    mock_deps_command.assert_called_once_with(*r_args, **r_kwargs)
+
+
+def test_deps_cli_add_sync_verify(mock_deps_command):
+    """Run deps add with sync and verify options
+
+    - mock deps_command
+    - check args
+    """
+    action = "add"
+    depsconfig = Path.cwd() / project_main.DEFAULT_CONFIG_NAME
+    srcname = "foo"
+    srctype = "metadata"
+    deps_args = [
+        "deps",
+        action,
+        srcname,
+        srctype,
+        "--sync",
+        "--verify",
+        "--verify-ignore-version",
+        "--verify-exclude",
+        "wheel$",
+    ]
+
+    r_args = (action, Path(depsconfig))
+    r_kwargs = dict(
+        DEFAULT_DEPS_ADD_CLI_KWARGS,
+        srcname=srcname,
+        srctype=srctype,
+        sync=True,
+        verify=True,
+        verify_ignore_version=True,
+        verify_excludes=["wheel$"],
+    )
+
+    project_main.main(deps_args)
+    mock_deps_command.assert_called_once_with(*r_args, **r_kwargs)
+
+
+@pytest.mark.parametrize(
+    "verify_command",
+    (["--verify"], ["--verify-exclude", "x$"], ["--verify-ignore-version"]),
+    ids=lambda x: x[0],
+)
+def test_deps_cli_add_verify_without_sync(
+    verify_command,
+    capsys,
+    mock_deps_command,
+):
+    """Run deps add with verify commands
+
+    - mock deps_command
+    - check error
+    """
+    action = "add"
+    srcname = "foo"
+    srctype = "metadata"
+    deps_args = ["deps", action, srcname, srctype, *verify_command]
+
+    with pytest.raises(SystemExit) as exc:
+        project_main.main(deps_args)
+    assert exc.value.code == ExitCodes.WRONG_USAGE
+    expected_message = "--verify options on add must be used with --sync"
+    assert expected_message in capsys.readouterr().err
+    mock_deps_command.assert_not_called()
+
+
+def test_deps_cli_add_sync_verify_drift_exits(mock_deps_command):
+    """Run deps add with sync and failed verify
+
+    - mock deps_command
+    - raise DepsUnsyncedError
+    - check exit code
+    """
+    action = "add"
+    srcname = "foo"
+    srctype = "metadata"
+    mock_deps_command.side_effect = project_main.DepsUnsyncedError
+    deps_args = ["deps", action, srcname, srctype, "--sync", "--verify"]
+
+    with pytest.raises(SystemExit) as exc:
+        project_main.main(deps_args)
+    assert exc.value.code == ExitCodes.SYNC_VERIFY_ERROR
+
+
+@pytest.mark.parametrize(
+    "verify_subcommand",
+    (["--verify-exclude", "x$"], ["--verify-ignore-version"]),
+    ids=lambda x: x[0],
+)
+def test_deps_cli_add_sync_verify_options_require_verify(
+    verify_subcommand,
+    mock_deps_command,
+    capsys,
+):
+    """Run deps add with sync and verify-* without verify
+
+    - mock deps_command
+    - check error
+    """
+    action = "add"
+    srcname = "foo"
+    srctype = "metadata"
+    deps_args = [
+        "deps",
+        action,
+        srcname,
+        srctype,
+        "--sync",
+        *verify_subcommand,
+    ]
+
+    with pytest.raises(SystemExit) as exc:
+        project_main.main(deps_args)
+    assert exc.value.code == ExitCodes.WRONG_USAGE
+    expected = f"{verify_subcommand[0]} option must be used with --verify"
+    assert expected in capsys.readouterr().err
+    mock_deps_command.assert_not_called()
 
 
 def test_deps_cli_delete_help(capsys):


### PR DESCRIPTION
Downstream packaging configures and verifies each dependency source with a `show || add` guard plus a separate `sync --verify`, spawning two or three `python -m pyproject_installer` processes per source where interpreter startup dominates. Fold that into one `add` call:

- deps add --reconfigure: make add idempotent. Keep the source when its type and args are unchanged, replace it (dropping stored deps) when they differ, instead of erroring on an existing name. Removes the `show ||` guard.
- deps add --sync: after a successful add, sync the source in the same process, sharing the existing sync verify options (--verify, --verify-exclude, --verify-ignore-version) via a new add_sync_options helper. One `add` call replaces the `show || add` + `sync` sequence.

Fixes: https://github.com/stanislavlevin/pyproject_installer/issues/157

## Summary by Sourcery

Add new dependency configuration options to make `deps add` idempotent and able to sync in a single call, and extend CLI, config handling, and docs accordingly.

New Features:
- Introduce `--reconfigure` flag to `deps add` to allow reconfiguring existing sources without error, keeping or replacing them based on type and args.
- Add `--sync` flag to `deps add` so a source can be configured and synced (with optional verification) in the same process, reusing existing sync verify options.

Bug Fixes:
- Ensure `deps add --sync` does not run sync when the add operation fails and returns appropriate exit codes on verification drift or usage errors.

Enhancements:
- Refactor sync verification option wiring into a shared helper so `deps add` and `deps sync` share consistent CLI behavior and validation rules.

Documentation:
- Document the new `--reconfigure` and `--sync` options for `deps add` in the README with usage details and examples.
- Add a design document explaining the motivation and behavior of `deps add --reconfigure` and `--sync` for downstream packaging workflows.

Tests:
- Add unit tests covering reconfigure semantics for `deps add`, including keeping or replacing sources and dropping stored deps as appropriate.
- Add CLI tests for `deps add` with `--reconfigure`, `--sync`, and verify options, including validation of incorrect flag combinations and exit codes.