### PR TITLE
feat(deps): add `metadata_extra` source for a core-metadata extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,7 +428,7 @@ Configure source of Python dependencies. Supported sources: standardized formats
 >
 > Omit when using `--candidates`.
 >
-> *Choices:* `pep517`, `pep518`, `pep735`, `metadata`, `pip_reqfile`, `poetry`, `tox`, `hatch`, `pdm`, `pipenv`
+> *Choices:* `pep517`, `pep518`, `pep735`, `metadata`, `metadata_extra`, `pip_reqfile`, `poetry`, `tox`, `hatch`, `pdm`, `pipenv`
 
 > **`<source-specific options>`** (positional, variadic)
 >
@@ -476,6 +476,12 @@ python -m pyproject_installer deps add build_pep517 pep517
 # core metadata dependencies
 python -m pyproject_installer deps add runtime metadata
 
+# core metadata extra
+# (its deps are the project's full core dependency list, not just the
+# extra's delta; the extra is stored in the source and applied
+# automatically at eval, so no eval --extra is needed)
+python -m pyproject_installer deps add check metadata_extra tests
+
 # PEP 735 dependency group
 python -m pyproject_installer deps add check pep735 test
 
@@ -500,7 +506,7 @@ python -m pyproject_installer deps add check pipenv Pipfile packages
 # autodiscover a test-dependency source (first existing wins), then
 # reconcile and verify it in one process
 python -m pyproject_installer deps add check \
-    --candidates 'pep735 test;pep735 tests;pip_reqfile test-requirements.txt' \
+    --candidates 'pep735 test;pep735 tests;pip_reqfile test-requirements.txt;metadata_extra tests' \
     --reconfigure --sync --verify
 ```
 
@@ -579,6 +585,8 @@ Evaluate stored requirements according to PEP 508 in current Python environment 
 > *Default:* `None`
 >
 > *Example:* `python -m pyproject_installer deps eval build --extra tests`
+>
+> A `metadata_extra` source carries its own recorded extra: that extra is always applied to its stored dependencies, and `--extra` is ignored for that source (it still applies to other sources).
 
 > **`--exclude`**
 >

--- a/docs/designs/metadata_extra_collector.md
+++ b/docs/designs/metadata_extra_collector.md
@@ -1,0 +1,182 @@
+## Abstract
+This RFE proposes a new `metadata_extra` collector type that takes
+an extra name, validates it against the project's `Provides-Extra`,
+and stores the project's full `Requires-Dist` list independently of
+the base `metadata` source. `eval` recognizes this source type and
+evaluates its stored deps with the source's own recorded extra,
+ignoring any `--extra` given on the command line. This lets an
+optional-dependency group (for example a `tests` extra) be
+configured through `deps add --candidates`, synced, and evaluated
+uniformly, without the caller needing to know which candidate won.
+
+## Motivation
+A project's test (or other optional) dependencies often live in an
+extra. Today a consumer can only select an extra at `eval` time via
+`--extra`, so "the deps of the `tests` extra" cannot be a configured
+source and cannot take part in `deps add --candidates` discovery. A
+candidates list like
+
+```
+'pep735 tests;metadata_extra tests;metadata_extra dev'
+```
+
+should pick the first that exists and record it, so the downstream
+`eval` is the same command regardless of which candidate matched.
+The caller cannot know the winner — only the config does — so the
+selected extra must be carried in the config and applied by `eval`
+itself.
+
+Why a full list instead of just the extra's delta: isolating "only
+the deps that apply under extra E, with the `extra == E` marker
+stripped" requires inspecting and rewriting markers, which the
+public `packaging` API does not offer. Storing the full
+`Requires-Dist` and evaluating with the extra set avoids changing
+markers at all, using only public API.
+
+## Specification
+
+### Collector
+New type `metadata_extra`, `name = "metadata_extra"`, registered in
+`SUPPORTED_COLLECTORS`, implemented as a subclass of
+`MetadataCollector` — it reuses the base's build-and-parse logic
+instead of reimplementing it.
+
+Building METADATA is the expensive step (it may build a wheel), and
+the subclass needs two things out of it: the `Provides-Extra`
+headers to validate the extra, and the `Requires-Dist` list to
+yield. To build and parse the metadata only once per `collect()`,
+split the base's current `collect()` into reusable methods on
+`MetadataCollector`:
+
+- `parsed_metadata() -> email.message.Message` — the expensive part:
+  build METADATA into a temp dir, read its text, and parse it once
+  with stdlib `email`, returning the parsed message.
+- `iter_requires(metadata) -> Iterator[str]` — the cheap part: take
+  the parsed message, read its `Requires-Dist`, run the base's
+  `is_pep508_requirement` validation, and yield the same requirement
+  strings (and the same error) as today.
+
+The base `collect()` becomes `iter_requires(parsed_metadata())` —
+behavior and error message unchanged. The subclass calls
+`parsed_metadata()` once, reads `Provides-Extra` from that same
+message to validate the extra, then reuses `iter_requires()` on it —
+so the metadata text is parsed only once.
+
+Requirement parsing deliberately stays on the base's stdlib `email`
+path rather than `packaging.metadata.Metadata`: `Metadata`'s
+`requires_dist` raises `InvalidMetadata` on a bad dependency, which
+would replace the base collector's established `"<name>: invalid
+PEP508 Dependency Specifier: ..."` error. `Provides-Extra` is parsed
+the same way (`email` + `utils.canonicalize_name` for PEP 503/685
+normalization), so no new `_vendor` re-export is needed.
+
+`MetadataExtraCollector(extra: str)` — `srcargs = (extra,)`,
+required (exactly one argument; zero or more than one is a config
+error, caught by the existing `validate_collector`).
+
+`collect()`:
+1. Call `parsed_metadata()` once (one build, one parse).
+2. Raise `ValueError` if the normalized extra is not among the
+   normalized `Provides-Extra` headers. This makes a typo loud, and
+   during `--candidates` discovery it lets a project that does not
+   declare the extra be skipped so the next candidate is tried.
+3. `yield from iter_requires(metadata)` — the full `Requires-Dist`
+   list unchanged (markers intact), reusing the base's logic rather
+   than duplicating it.
+
+### eval
+`eval` must apply the source's recorded extra to that source's
+stored deps. So `eval` does not need to know about specific
+collector types, it asks each collector for its marker-environment
+contribution instead of checking the source type name:
+
+- New instance method on the `Collector` base:
+  `eval_env(self) -> dict[str, str]`, default `{}`.
+- `MetadataExtraCollector.eval_env` returns `{"extra": self.extra}`,
+  reusing the extra already parsed from `srcargs` in `__init__` — so
+  the meaning of `srcargs` lives only in the constructor, not
+  re-derived here.
+- In `eval`, for each source, instantiate the collector via the
+  existing `validate_collector(srctype, srcargs)` (same call used by
+  `collect`/`sync`; no build), call `eval_env()`, and merge the
+  result into the marker environment used to evaluate that source's
+  deps.
+
+For a `metadata_extra` source the recorded extra **takes
+precedence**: a CLI `--extra` is ignored for that source's deps (it
+still applies to other sources as today).
+
+Why ignore a given `--extra`: the source stores the *full*
+`Requires-Dist`, so its extra-gated deps only surface when evaluated
+with that one recorded extra. A different `--extra` (or none) would
+silently emit the wrong subset — a different extra's deps, or none
+of them. And the whole point of recording the extra in config is
+that the caller does not know which candidate won (`metadata_extra
+tests` vs `dev` vs a `pep735` group), so it cannot supply the right
+`--extra` anyway. The stored extra is therefore the only correct one
+for that source, and honoring an external override could only break
+it.
+
+### Config validation
+A `metadata_extra` source takes exactly one `srcargs` entry (the
+extra name). No reference to other sources is stored; the source is
+self-contained.
+
+## Accepted trade-offs
+- The stored deps duplicate the base `metadata` source's deps. The
+  config is machine-generated, so this is cosmetic.
+- `sync --verify` on a `metadata_extra` source reports drift when
+  *any* extra's deps change, not only the recorded one, since the
+  full list is stored.
+- No caching of METADATA builds: each `metadata_extra` probe/sync
+  triggers its own build. List cheaper source types first in
+  candidate lists, so `metadata_extra` is reached only when needed.
+
+## Rejected ideas
+
+### Reuse an existing `metadata` source instead of storing deps independently
+Rather than building and storing its own full `Requires-Dist`,
+`metadata_extra` could point at a configured `metadata` source and
+reuse its stored deps (storing only a reference and the extra,
+`metadata_extra <metadata_src> <extra>`). This removes the
+duplication and the second METADATA build, but was rejected because:
+
+- **Coupling.** `srcargs` must carry the target source name, and
+  config validation must check the target exists and is a `metadata`
+  source — the source is no longer self-contained.
+- **Coherence.** `eval` would read the target's stored deps, so the
+  target must be fresh; an unsynced or absent target yields stale or
+  missing deps. This forces a "sync pulls the target in" rule that
+  complicates `sync`.
+- **Validation gap.** The extra-existence check needs
+  `Provides-Extra`, which a `metadata` source's *stored deps* do not
+  carry. So `--candidates` discovery would either lose its cheap
+  "does this extra exist?" check or have to build METADATA anyway —
+  removing the main saving.
+
+In summary, it trades duplication for cross-source coupling plus a
+gap in discovery validation. Independent storage keeps
+`metadata_extra` a normal, self-contained source that works in
+`--candidates` without referencing anything.
+
+## Example
+
+```
+# discover the tests extra; the first candidate that exists wins
+python -m pyproject_installer deps add check \
+    --candidates 'pep735 tests;metadata_extra tests' \
+    --sync
+
+# same command regardless of which candidate won:
+python -m pyproject_installer deps eval check
+```
+
+With no `tests` dependency group, `pep735 tests` is skipped and
+`metadata_extra tests` wins. Given `Provides-Extra: tests` and
+`Requires-Dist: pytest; extra == "tests"`, the `check` source
+stores the full `Requires-Dist` and records extra `tests`; `eval`
+evaluates each marker with `extra == "tests"` set, so the
+`pytest` requirement is included and printed as
+`pytest; extra == "tests"`. If a `pep735` `tests` group existed
+instead, it would have won and `eval_env` would contribute nothing —
+the same `eval check` works.

--- a/src/pyproject_installer/deps_cmd/collectors/__init__.py
+++ b/src/pyproject_installer/deps_cmd/collectors/__init__.py
@@ -1,6 +1,7 @@
 from .collector import Collector
 from .hatch import HatchCollector
 from .metadata import MetadataCollector
+from .metadata_extra import MetadataExtraCollector
 from .pdm import PdmCollector
 from .pep517 import Pep517Collector
 from .pep518 import Pep518Collector
@@ -18,6 +19,7 @@ _COLLECTOR_CLASSES: list[type[Collector]] = [
     Pep517Collector,
     Pep518Collector,
     MetadataCollector,
+    MetadataExtraCollector,
     PipReqFileCollector,
     PoetryCollector,
     ToxCollector,

--- a/src/pyproject_installer/deps_cmd/collectors/collector.py
+++ b/src/pyproject_installer/deps_cmd/collectors/collector.py
@@ -9,3 +9,24 @@ class Collector(ABC):
     @abstractmethod
     def collect(self) -> Iterator[str]:
         """Implements collecting list of dependencies from sources"""
+
+    def eval_env(self) -> dict[str, str]:
+        """Marker environment this source contributes at eval time.
+
+        Returns a mapping of PEP 508 marker variables to values (for
+        example ``{"extra": "tests"}``). During ``eval`` it is merged
+        into the marker environment used to evaluate this source's
+        stored dependencies, and it takes precedence over a value
+        passed on the command line (such as ``--extra``). Only the
+        variables present in the returned mapping are set; everything
+        else in the environment is left at its default, so unrelated
+        markers (``python_version``, ``sys_platform``, ...) still
+        evaluate against the current environment. The contribution
+        only decides which dependencies are kept; it does not rewrite
+        the dependency strings that are printed.
+
+        Default: an empty mapping, i.e. no contribution. A collector
+        that records a fixed marker variable (for example an extra)
+        overrides this.
+        """
+        return {}

--- a/src/pyproject_installer/deps_cmd/collectors/metadata.py
+++ b/src/pyproject_installer/deps_cmd/collectors/metadata.py
@@ -1,5 +1,6 @@
 import email
 from collections.abc import Iterator
+from email.message import Message
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -21,7 +22,8 @@ class MetadataCollector(Collector):
 
     name = "metadata"
 
-    def collect(self) -> Iterator[str]:
+    def parsed_metadata(self) -> Message:
+        """Build the project's core metadata on cwd and parse it once."""
         with TemporaryDirectory() as tmpdir:
             tmp_path = Path(tmpdir)
             metadata_filename = build_metadata(
@@ -30,8 +32,11 @@ class MetadataCollector(Collector):
             )
             metadata_path = tmp_path / metadata_filename
             metadata_text = metadata_path.read_text(encoding="utf-8")
-        metadata_email = email.message_from_string(metadata_text)
-        requires = metadata_email.get_all("Requires-Dist", [])
+        return email.message_from_string(metadata_text)
+
+    def iter_requires(self, metadata: Message) -> Iterator[str]:
+        """Parse and validate Requires-Dist from parsed metadata."""
+        requires = metadata.get_all("Requires-Dist", [])
         for req in requires:
             if not is_pep508_requirement(req):
                 err_msg = (
@@ -39,3 +44,6 @@ class MetadataCollector(Collector):
                 )
                 raise ValueError(err_msg) from None
             yield req
+
+    def collect(self) -> Iterator[str]:
+        yield from self.iter_requires(self.parsed_metadata())

--- a/src/pyproject_installer/deps_cmd/collectors/metadata_extra.py
+++ b/src/pyproject_installer/deps_cmd/collectors/metadata_extra.py
@@ -1,0 +1,37 @@
+from collections.abc import Iterator
+
+from ...lib import utils
+from .metadata import MetadataCollector
+
+
+class MetadataExtraCollector(MetadataCollector):
+    """Record a project's optional-dependency group (extra) as a source.
+
+    Builds the project's core metadata, validates that the requested
+    extra is declared (Provides-Extra), and stores the full
+    Requires-Dist list unchanged (markers intact). At eval time the
+    recorded extra is applied via eval_env(), so the extra-gated deps
+    surface without a command-line --extra.
+    """
+
+    name = "metadata_extra"
+
+    def __init__(self, extra: str) -> None:
+        self.extra = extra
+
+    def collect(self) -> Iterator[str]:
+        metadata = self.parsed_metadata()
+        provided = {
+            utils.canonicalize_name(e)
+            for e in metadata.get_all("Provides-Extra", [])
+        }
+        if utils.canonicalize_name(self.extra) not in provided:
+            err_msg = (
+                f"{self.name}: extra '{self.extra}' not provided by project "
+                f"(available: {', '.join(sorted(provided))})"
+            )
+            raise ValueError(err_msg) from None
+        yield from self.iter_requires(metadata)
+
+    def eval_env(self) -> dict[str, str]:
+        return {"extra": self.extra}

--- a/src/pyproject_installer/deps_cmd/deps_config.py
+++ b/src/pyproject_installer/deps_cmd/deps_config.py
@@ -461,15 +461,31 @@ class DepsSourcesConfig:
         exclude_regexes = {re.compile(x) for x in excludes}
 
         for _, source in self.iter_sources(srcnames):
+            # instantiate the collector for its eval_env() marker contribution;
+            # the type and args were already validated at config load
+            collector = self.validate_collector(
+                source["srctype"],
+                tuple(source.get("srcargs", ())),
+            )
+            source_env = collector.eval_env()
             for req in source.get("deps", ()):
                 parsed_req = requirements.Requirement(req)
 
                 # evaluating markers
                 marker = parsed_req.marker
                 if marker is not None:
+                    # build an override mapping only when there is something
+                    # to override; pass None otherwise so the marker is
+                    # evaluated against packaging's default environment (its
+                    # documented contract for None). A source's recorded extra
+                    # (via eval_env) takes precedence over a command-line
+                    # --extra.
                     env = None
                     if extra is not None:
                         env = {"extra": extra}
+
+                    if source_env:
+                        env = (env or {}) | source_env
                     marker_res = marker.evaluate(env)
                     if not marker_res:
                         continue

--- a/tests/unit/test_deps/conftest.py
+++ b/tests/unit/test_deps/conftest.py
@@ -77,3 +77,24 @@ def mock_collector(mocker):
         )
 
     return _collector
+
+
+@pytest.fixture
+def pyproject_metadata_extra(pyproject_metadata):
+    """
+    project with self-hosted build backend providing
+    prepare_metadata_for_build_wheel which generates metadata containing extras
+    """
+
+    def _pyproject_metadata_extra(extra, **kwargs):
+        return pyproject_metadata(
+            headers=[
+                "Metadata-Version: 2.1",
+                "Name: foo",
+                "Version: 1.0",
+                f"Provides-Extra: {extra}",
+            ],
+            **kwargs,
+        )
+
+    return _pyproject_metadata_extra

--- a/tests/unit/test_deps/test_collectors/test_metadata_extra.py
+++ b/tests/unit/test_deps/test_collectors/test_metadata_extra.py
@@ -1,0 +1,205 @@
+import json
+import re
+from copy import deepcopy
+
+import pytest
+
+from pyproject_installer.deps_cmd import deps_command
+from pyproject_installer.errors import DepsSourcesConfigError
+
+
+def test_metadata_extra_collects_full_list(
+    pyproject_metadata_extra,
+    depsconfig,
+):
+    """metadata_extra stores the full Requires-Dist, markers intact."""
+    srcname = "check"
+    collector = "metadata_extra"
+    extra = "bar"
+    input_conf = {
+        "sources": {
+            srcname: {"srctype": collector, "srcargs": [extra]},
+        },
+    }
+    depsconfig_path = depsconfig(json.dumps(input_conf))
+
+    pyproject_metadata_extra(extra, reqs=("qux", f"baz; extra == '{extra}'"))
+
+    deps_command("sync", depsconfig_path, srcnames=[])
+
+    expected_conf = deepcopy(input_conf)
+    expected_conf["sources"][srcname]["deps"] = [
+        f'baz; extra == "{extra}"',
+        "qux",
+    ]
+    actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))
+    assert actual_conf == expected_conf
+
+
+def test_metadata_extra_normalizes_extra(
+    pyproject_metadata_extra,
+    depsconfig,
+):
+    """The requested extra is matched PEP 503/685-normalized."""
+    srcname = "check"
+    collector = "metadata_extra"
+    extra = "bar"
+    input_conf = {
+        "sources": {
+            srcname: {
+                "srctype": collector,
+                "srcargs": [extra.capitalize()],
+            },
+        },
+    }
+    depsconfig_path = depsconfig(json.dumps(input_conf))
+
+    pyproject_metadata_extra(extra, reqs=(f"baz; extra == '{extra}'",))
+
+    deps_command("sync", depsconfig_path, srcnames=[])
+
+    actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))
+    expected_conf = deepcopy(input_conf)
+    expected_conf["sources"][srcname]["deps"] = [f'baz; extra == "{extra}"']
+    assert actual_conf == expected_conf
+
+
+def test_metadata_extra_unknown_extra_raises(
+    pyproject_metadata_extra,
+    depsconfig,
+):
+    """An extra not in Provides-Extra is a loud error (skips in candidates)."""
+    srcname = "check"
+    collector = "metadata_extra"
+    extra = "bar"
+    unknown = "nope"
+    input_conf = {
+        "sources": {
+            srcname: {"srctype": collector, "srcargs": [unknown]},
+        },
+    }
+    depsconfig_path = depsconfig(json.dumps(input_conf))
+
+    pyproject_metadata_extra(extra, reqs=(f"baz; extra == '{extra}'",))
+
+    expected_err = "^" + re.escape(
+        f"{collector}: extra '{unknown}' not provided by project "
+        f"(available: {extra})",
+    )
+    with pytest.raises(ValueError, match=expected_err):
+        deps_command("sync", depsconfig_path, srcnames=[])
+
+    # config unchanged on failure
+    actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))
+    assert actual_conf == input_conf
+
+
+def test_metadata_extra_requires_exactly_one_arg(depsconfig):
+    """Zero srcargs is a config error caught by validate_collector."""
+    collector = "metadata_extra"
+    input_conf = {"sources": {"check": {"srctype": collector}}}
+    depsconfig_path = depsconfig(json.dumps(input_conf))
+
+    with pytest.raises(DepsSourcesConfigError):
+        deps_command("sync", depsconfig_path, srcnames=[])
+
+    # config unchanged on failure
+    actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))
+    assert actual_conf == input_conf
+
+
+def test_metadata_extra_rejects_too_many_args(depsconfig):
+    """More than one srcarg is a config error caught by validate_collector."""
+    collector = "metadata_extra"
+    input_conf = {
+        "sources": {
+            "check": {"srctype": collector, "srcargs": ["bar", "baz"]},
+        },
+    }
+    depsconfig_path = depsconfig(json.dumps(input_conf))
+
+    with pytest.raises(DepsSourcesConfigError):
+        deps_command("sync", depsconfig_path, srcnames=[])
+
+    # config unchanged on failure
+    actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))
+    assert actual_conf == input_conf
+
+
+def test_metadata_extra_invalid_dep_raises(
+    pyproject_metadata_extra,
+    depsconfig,
+):
+    """A malformed Requires-Dist raises under the metadata_extra name."""
+    srcname = "check"
+    collector = "metadata_extra"
+    extra = "bar"
+    invalid_dep = "_foo"
+    input_conf = {
+        "sources": {
+            srcname: {"srctype": collector, "srcargs": [extra]},
+        },
+    }
+    depsconfig_path = depsconfig(json.dumps(input_conf))
+
+    pyproject_metadata_extra(extra, reqs=(invalid_dep,))
+
+    expected_err = "^" + re.escape(
+        f"{collector}: invalid PEP508 Dependency Specifier: {invalid_dep}",
+    )
+    with pytest.raises(ValueError, match=expected_err):
+        deps_command("sync", depsconfig_path, srcnames=[])
+
+    # config unchanged on failure
+    actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))
+    assert actual_conf == input_conf
+
+
+def test_metadata_extra_no_provided_extras(pyproject_metadata, depsconfig):
+    """With no Provides-Extra the error's available list is empty."""
+    srcname = "check"
+    collector = "metadata_extra"
+    extra = "bar"
+    input_conf = {
+        "sources": {
+            srcname: {"srctype": collector, "srcargs": [extra]},
+        },
+    }
+    depsconfig_path = depsconfig(json.dumps(input_conf))
+
+    # default headers carry no Provides-Extra
+    pyproject_metadata(reqs=())
+
+    expected_err = "^" + re.escape(
+        f"{collector}: extra '{extra}' not provided by project "
+        "(available: )",
+    )
+    with pytest.raises(ValueError, match=expected_err):
+        deps_command("sync", depsconfig_path, srcnames=[])
+
+    # config unchanged on failure
+    actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))
+    assert actual_conf == input_conf
+
+
+def test_metadata_extra_extra_with_no_deps(
+    pyproject_metadata_extra,
+    depsconfig,
+):
+    """A provided extra with no Requires-Dist stores no deps."""
+    srcname = "check"
+    collector = "metadata_extra"
+    extra = "bar"
+    input_conf = {
+        "sources": {
+            srcname: {"srctype": collector, "srcargs": [extra]},
+        },
+    }
+    depsconfig_path = depsconfig(json.dumps(input_conf))
+
+    pyproject_metadata_extra(extra, reqs=())
+
+    deps_command("sync", depsconfig_path, srcnames=[])
+
+    actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))
+    assert actual_conf == input_conf

--- a/tests/unit/test_deps/test_deps_add.py
+++ b/tests/unit/test_deps/test_deps_add.py
@@ -510,6 +510,44 @@ def test_config_add_candidates_uncollectable_is_skipped(
     assert actual_conf == expected_conf
 
 
+def test_config_add_candidates_metadata_extra_unknown_skipped(
+    depsconfig_path,
+    pyproject_metadata_extra,
+):
+    """A metadata_extra whose extra is undeclared is skipped; next wins.
+
+    Exercises the feature's headline discovery path: an unknown extra
+    makes the collector raise, so the candidate walk moves on to the
+    declared extra.
+    """
+
+    action = "add"
+    srcname = "check"
+    collector = "metadata_extra"
+    extra = "bar"
+    unknown = "nope"
+    candidates = (
+        (collector, unknown),  # extra not provided -> skipped
+        (collector, extra),  # provided -> picked
+    )
+
+    pyproject_metadata_extra(extra, reqs=(f"baz; extra == '{extra}'",))
+
+    deps_command(
+        action,
+        depsconfig_path,
+        srcname=srcname,
+        candidates=candidates,
+    )
+    actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))
+    expected_conf = {
+        "sources": {
+            srcname: {"srctype": collector, "srcargs": [extra]},
+        },
+    }
+    assert actual_conf == expected_conf
+
+
 def test_config_add_candidates_no_candidate_unconfigured_errors(
     depsconfig_path,
 ):

--- a/tests/unit/test_deps/test_deps_config.py
+++ b/tests/unit/test_deps/test_deps_config.py
@@ -1156,3 +1156,51 @@ def test_config_eval_excludes(deps, depsconfig, capsys):
     captured = capsys.readouterr()
     assert not captured.err
     assert captured.out == expected_out
+
+
+def test_config_eval_metadata_extra_applies_stored_extra(depsconfig, capsys):
+    """A metadata_extra source evaluates with its recorded extra."""
+    action = "eval"
+    collector = "metadata_extra"
+    deps = ["qux", 'baz; extra == "bar"', 'corge; extra == "quux"']
+    input_conf = {
+        "sources": {
+            "check": {
+                "srctype": collector,
+                "srcargs": ["bar"],
+                "deps": deps,
+            },
+        },
+    }
+    depsconfig_path = depsconfig(json.dumps(input_conf))
+
+    # No --extra on the command line: the stored extra drives evaluation.
+    deps_command(action, depsconfig_path, srcnames=[])
+
+    captured = capsys.readouterr()
+    assert not captured.err
+    assert captured.out == 'baz; extra == "bar"\nqux\n'
+
+
+def test_config_eval_metadata_extra_ignores_cli_extra(depsconfig, capsys):
+    """For metadata_extra, the recorded extra wins over a CLI --extra."""
+    action = "eval"
+    collector = "metadata_extra"
+    deps = ['baz; extra == "bar"', 'corge; extra == "quux"']
+    input_conf = {
+        "sources": {
+            "check": {
+                "srctype": collector,
+                "srcargs": ["bar"],
+                "deps": deps,
+            },
+        },
+    }
+    depsconfig_path = depsconfig(json.dumps(input_conf))
+
+    # CLI asks for "quux", but the source records "bar" and wins.
+    deps_command(action, depsconfig_path, srcnames=[], extra="quux")
+
+    captured = capsys.readouterr()
+    assert not captured.err
+    assert captured.out == 'baz; extra == "bar"\n'


### PR DESCRIPTION
A project's test (or other optional) dependencies often live in a core-metadata extra. Until now an extra could only be selected at `eval` time via `--extra`, so the deps of an extra could not be a configured source and could not take part in `deps add --candidates` discovery -- downstream packaging that probes a list of likely test-dependency sources had no way to offer a project's extra as one of the candidates.

Add a `metadata_extra` collector that records an extra as an ordinary, self-contained source (`deps add <name> metadata_extra <extra>`). It builds the project's core metadata, validates that the extra is declared in `Provides-Extra` (raising if absent, so a typo is loud and `--candidates` discovery skips a project lacking the extra), and stores the full `Requires-Dist` list.

- Split `MetadataCollector.collect()` into `parsed_metadata()` and `iter_requires()`; the subclass reuses one METADATA build and the base collector's PEP 508 error contract is unchanged (parsing stays on stdlib `email`).
- Add a generic `Collector.eval_env()` hook (default empty). At `eval` time it is merged into the marker environment, so a `metadata_extra` source's recorded extra is applied to its own deps and takes precedence over a command-line `--extra`. Evaluation only selects which requirements are emitted; the printed requirement keeps its marker, as with the existing `--extra`.

Storing the full `Requires-Dist` rather than only the extra's own deps is deliberate: isolating just the deps that apply under an extra would require rewriting environment markers, which the public `packaging` API does not offer; evaluating the stored list with the extra set produces the same result using only public API.

Fixes: https://github.com/stanislavlevin/pyproject_installer/issues/161

## Summary by Sourcery

Add support for treating a project extra declared in core metadata as a first-class dependency source and ensure it participates in candidate discovery and evaluation.

New Features:
- Introduce a metadata_extra collector that records an extra from core metadata as a standalone dependency source and exposes its dependencies for sync and eval.
- Allow collectors to contribute a per-source marker evaluation environment so sources like metadata_extra can apply their own recorded extras during dependency evaluation.

Enhancements:
- Refactor the metadata collector to separate metadata building/parsing from requirement iteration, enabling reuse by specialized collectors like metadata_extra.

Documentation:
- Document the new metadata_extra collector, its behavior, and usage in README and add a detailed design document describing its motivation and implementation.

Tests:
- Add unit tests covering metadata_extra collection behavior, extra normalization and validation errors, candidate discovery integration, and eval semantics where recorded extras override CLI-provided extras.