### PR TITLE
test(deps): cover PEP 503/685 extra-name normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,7 +580,7 @@ Evaluate stored requirements according to PEP 508 in current Python environment 
 
 > **`--extra`**
 >
-> PEP 508 `extra` marker to evaluate with.
+> PEP 508 `extra` marker to evaluate with. Before evaluation the supplied name and each dependency's `extra == ...` marker value are both PEP 503/685-normalized, then compared in that normalized form, so `Foo.Bar`, `foo_bar` and `foo-bar` are equivalent.
 >
 > *Default:* `None`
 >

--- a/tests/unit/test_deps/test_collectors/test_metadata_extra.py
+++ b/tests/unit/test_deps/test_collectors/test_metadata_extra.py
@@ -36,31 +36,41 @@ def test_metadata_extra_collects_full_list(
     assert actual_conf == expected_conf
 
 
+@pytest.mark.parametrize(
+    "requested",
+    ("foo-bar", "Foo.Bar", "foo_bar", "FOO-BAR"),
+)
+@pytest.mark.parametrize("header", ("foo-bar", "Foo.Bar", "foo_bar", "FOO_BAR"))
 def test_metadata_extra_normalizes_extra(
+    header,
+    requested,
     pyproject_metadata_extra,
     depsconfig,
 ):
-    """The requested extra is matched PEP 503/685-normalized."""
+    """The extra is matched PEP 503/685-normalized on both the requested
+    and the Provides-Extra (provided) side."""
     srcname = "check"
     collector = "metadata_extra"
-    extra = "bar"
     input_conf = {
         "sources": {
             srcname: {
                 "srctype": collector,
-                "srcargs": [extra.capitalize()],
+                "srcargs": [requested],
             },
         },
     }
     depsconfig_path = depsconfig(json.dumps(input_conf))
 
-    pyproject_metadata_extra(extra, reqs=(f"baz; extra == '{extra}'",))
+    pyproject_metadata_extra(header, reqs=(f"baz; extra == '{header}'",))
 
     deps_command("sync", depsconfig_path, srcnames=[])
 
     actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))
     expected_conf = deepcopy(input_conf)
-    expected_conf["sources"][srcname]["deps"] = [f'baz; extra == "{extra}"']
+    # sync() round-trips each dep through Requirement -> str, and packaging
+    # normalizes the extra marker on the way, so the stored form is foo-bar
+    # regardless of the header's spelling.
+    expected_conf["sources"][srcname]["deps"] = ['baz; extra == "foo-bar"']
     assert actual_conf == expected_conf
 
 

--- a/tests/unit/test_deps/test_deps_config.py
+++ b/tests/unit/test_deps/test_deps_config.py
@@ -1134,6 +1134,30 @@ def test_config_eval_extra(data, depsconfig, capsys):
     assert captured.out == expected_out
 
 
+@pytest.mark.parametrize("marker_extra", ("te-st", "te_st", "Te.St", "TE-ST"))
+@pytest.mark.parametrize("extra", ("Te-St", "te_st", "te.st"))
+def test_config_eval_extra_normalized(extra, marker_extra, depsconfig, capsys):
+    """Both the --extra arg and the marker's extra value are normalized
+    before comparison (PEP 503/685), so any denormalized spelling of
+    either side selects the dep."""
+
+    action = "eval"
+    deps = [f'foo ; extra == "{marker_extra}"', 'bar ; extra == "doc"']
+
+    # prepare source config
+    input_conf = {"sources": {"foo": {"srctype": "metadata", "deps": deps}}}
+    depsconfig_path = depsconfig(json.dumps(input_conf))
+
+    deps_command(action, depsconfig_path, srcnames=[], extra=extra)
+
+    captured = capsys.readouterr()
+    assert not captured.err
+    # eval parses each dep through Requirement and prints str(parsed_req),
+    # and packaging normalizes the extra marker on the way, so the printed
+    # form is te-st regardless of the stored marker's spelling.
+    assert captured.out == 'foo; extra == "te-st"\n'
+
+
 @pytest.mark.parametrize("deps", (["foo", "foo_bar", "Bar", "foobar"],))
 def test_config_eval_excludes(deps, depsconfig, capsys):
     """Eval source with excludes"""


### PR DESCRIPTION
Extra names are compared in two paths: `eval --extra` (filtering each dependency's `extra == ...` marker) and the `metadata_extra` collector (validating the requested extra against `Provides-Extra`). Both already normalize per PEP 503/685 — `metadata_extra` via `canonicalize_name` in collect(), eval via vendored `packaging`, which normalizes both the environment `extra` and each marker value — but this was neither tested directly nor documented.

- parametrize the metadata_extra normalization test with a separator case (`Foo.Bar` -> `foo-bar`), not only case folding
- add an eval --extra test feeding denormalized inputs (`Te-St`, `te_st`, `te.st`) against an `extra == "te-st"` marker
- document in the README --extra entry that the supplied name and each marker's extra value are both normalized before comparison

See for details:
https://peps.python.org/pep-0685/

Fixes: https://github.com/stanislavlevin/pyproject_installer/issues/163

## Summary by Sourcery

Add coverage and documentation for PEP 503/685-style normalization of extras in dependency evaluation and metadata collection.

Bug Fixes:
- Ensure denormalized --extra arguments correctly match normalized extra markers in dependency evaluation.

Enhancements:
- Extend metadata_extra tests to cover separator and case normalization when matching provided vs. requested extras.

Documentation:
- Document in the README that both the supplied --extra value and dependency extra markers are PEP 503/685-normalized before comparison.

Tests:
- Add tests verifying that eval --extra and metadata_extra collector both normalize and correctly match extras with different case and separators.