### PR TITLE
feat(deps): add logging and split data/diagnostics streams

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -18,4 +18,5 @@ Builds/installs PEP 517/518 projects in network-isolated envs (RPM packaging). R
 - Non-isolated build; no build-dep checking (caller's job).
 - Install drops `RECORD` (PEP 627), no bytecompilation — by design.
 - pytest `filterwarnings = ["error"]` — warnings are errors.
+- Logging → **stderr** only; `stdout` is reserved for a command's machine-readable data (`deps eval`/`show`/`sync --verify`). Never `print()`/log diagnostics to stdout.
 - New features need tests + docs; new CLI opts → `README.md` with `name`/`description`/`example`.

--- a/README.md
+++ b/README.md
@@ -133,6 +133,21 @@ These options are accepted by the top-level command and must appear
 >
 > *Example:* `python -m pyproject_installer -C /path/to/project build`
 
+> **`-v, --verbose`**
+>
+> Raise diagnostic output from the default `INFO` level to `DEBUG`.
+>
+> *Default:* `INFO`
+>
+> *Example:* `python -m pyproject_installer -v build`
+
+Diagnostics (progress and logging) are written to `stderr`, while
+`stdout` carries only a command's machine-readable data: the
+dependency list from `deps eval`, the JSON from `deps show`, and the
+diff from `deps sync --verify`. The separation holds at any verbosity,
+so the data on `stdout` can be captured or piped without interleaved
+log lines.
+
 ### Build
 
 Build project from source tree in current Python environment according to

--- a/docs/designs/logging_streams_and_status.md
+++ b/docs/designs/logging_streams_and_status.md
@@ -1,0 +1,101 @@
+## Abstract
+This RFE splits the CLI's two output channels by purpose and makes the
+commands report their progress:
+
+- **Diagnostics go to stderr.** All `logging` records, every level,
+  are emitted on stderr. `stdout` is reserved exclusively for the
+  machine-readable *data* a command is asked to produce.
+- **Levels reflect intent.** A source-registry mutation or a
+  command's start/finish status is `INFO` (shown by default); plumbing,
+  no-ops, and internal walk detail are `DEBUG` (shown only under
+  `-v`).
+- **Commands report start and finish.** Each `deps` subcommand brackets
+  its work with an `INFO` start line and an `INFO` finish line on
+  stderr, as the top-level `build`/`install`/`run` commands already do.
+  The display-only `show` is the exception: it writes its data to
+  `stdout` and emits no diagnostics.
+
+Only `deps eval`, `deps show`, and `deps sync --verify` write data to
+`stdout` (via `sys.stdout.write`); `build` reports its result through
+the `.wheeltracker` file, not `stdout`. So no command outside `deps`
+has a `stdout` data contract, and moving all logging to stderr breaks
+none of them.
+
+## Motivation
+`setup_logging` currently routes `INFO` and `DEBUG` to `stdout` and
+`WARNING`+ to `stderr`. But three `deps` commands also write data to
+`stdout`:
+
+- `eval` -- the formatted dependency list;
+- `show` -- the config as JSON;
+- `sync --verify` -- the unsynced diff as JSON.
+
+Any log record on `stdout` interleaves with that data and corrupts it
+for the tool consuming it. Sending all diagnostics to `stderr` is the
+conventional Unix split (data on `stdout`, diagnostics on `stderr`):
+it keeps the data commands pristine at *any* verbosity and lets each
+message use the level it deserves, instead of being forced to `DEBUG`
+just to keep `stdout` clean.
+
+## Specification
+
+### Stream split
+`setup_logging` emits all records on a single
+`StreamHandler(sys.stderr)`. The separate `stdout` handler and the
+`emit_less_than_warning` filter are removed. The level is `DEBUG`
+when `-v/--verbose` is given, `INFO` otherwise; the existing formats
+are unchanged. After this, `stdout` carries only the explicit
+`sys.stdout.write` data of `deps eval`/`show`/`sync --verify`.
+
+### Level policy
+- `INFO` -- a change to the source registry the user asked for, or a
+  command's start/finish status. Visible by default.
+- `DEBUG` -- plumbing (config load/save, default-config init),
+  no-ops, and candidate-walk detail. Visible only under `-v`.
+
+The categories above cover the records the `deps` commands emit; the
+exact wording and level of each record live in the code and its tests,
+not here.
+
+### Per-command status (`deps`)
+Each subcommand maps to a `DepsSourcesConfig` method (`deps_command`
+dispatches via `getattr(config, action)`). Each brackets its work with
+two `INFO` lines on `stderr` -- a start (configuring, deleting, syncing,
+evaluating) and a finish reporting the outcome (configured, deleted,
+synced, evaluated) -- so neither touches the data the command writes to
+`stdout`. `show` is the exception: it only displays the stored config to
+`stdout` and emits no diagnostics. `sync --verify` keeps its existing
+contract: the diff is written to `stdout` and `DepsUnsyncedError` is
+raised (the dispatcher exits `SYNC_VERIFY_ERROR`).
+
+### Per-command status (top-level)
+`build`/`install`/`run` already end with an `INFO` result line; the
+audit confirmed each does, so none required a change and no unrelated
+logging is touched.
+
+### Compatibility and behaviour changes
+- `build`/`install`/`run` progress moves from `stdout` to `stderr`.
+  The documented filename-capture path is `{OUTDIR}/.wheeltracker`
+  (read back by `install`), which is unaffected, so no data contract
+  changes.
+- `run` streams the child's `stdout` through `logger.info`; that
+  child `stdout` now lands on the process `stderr` (child `stderr`,
+  via `logger.error`, was already there).
+- `deps eval`/`show`/`sync --verify` produce clean `stdout` at any
+  verbosity, including `-v`.
+
+## Example
+
+```console
+# The verify diff on stdout stays clean even with -v; all progress
+# and status go to stderr (here discarded), so the data on stdout can
+# be captured or piped without interleaved log lines.
+$ python -m pyproject_installer -v deps sync --verify check 2>/dev/null
+{
+  "check": {
+    "new_deps": [
+      "pytest"
+    ]
+  }
+}
+```

--- a/src/pyproject_installer/__main__.py
+++ b/src/pyproject_installer/__main__.py
@@ -823,19 +823,9 @@ def main_parser(prog: str) -> MainArgumentParser:
     return parser
 
 
-def emit_less_than_warning(record: logging.LogRecord) -> bool:
-    # nonzero if record should be logged
-    return record.levelno < logging.WARNING
-
-
 def setup_logging(*, verbose: bool = False) -> None:
-    # emit WARNING, ERROR and CRITICAL to stderr
+    # emit all diagnostics to stderr; stdout is reserved for data output
     stderr_handler = logging.StreamHandler(sys.stderr)
-    stderr_handler.setLevel(logging.WARNING)
-
-    # emit DEBUG and INFO to stdout
-    stdout_handler = logging.StreamHandler(sys.stdout)
-    stdout_handler.addFilter(emit_less_than_warning)
 
     if verbose:
         log_level = logging.DEBUG
@@ -846,7 +836,7 @@ def setup_logging(*, verbose: bool = False) -> None:
 
     logging.basicConfig(
         format=log_format,
-        handlers=(stdout_handler, stderr_handler),
+        handlers=(stderr_handler,),
         level=log_level,
     )
 

--- a/src/pyproject_installer/deps_cmd/deps_config.py
+++ b/src/pyproject_installer/deps_cmd/deps_config.py
@@ -1,9 +1,9 @@
 import json
+import logging
 import re
 import sys
 from collections import deque
 from collections.abc import Iterator, Mapping
-from contextlib import suppress
 from copy import deepcopy
 from pathlib import Path
 from string import Template
@@ -20,6 +20,8 @@ from .collectors import get_collector
 from .collectors.collector import Collector
 
 DEFAULT_CONFIG_NAME = "pyproject_deps.json"
+
+logger = logging.getLogger(__name__)
 
 
 class DepsConfigSourceBaseType(TypedDict):
@@ -118,6 +120,7 @@ class DepsSourcesConfig:
                     ) from e
                 self.validate_config(config)
                 self._config = config
+            logger.debug("Loaded config file %s", self.file)
         return self._config
 
     @config.setter
@@ -126,7 +129,7 @@ class DepsSourcesConfig:
         self.save()
 
     def set_default(self) -> None:
-        # default config
+        logger.debug("Initializing default config")
         self.config = {"sources": {}}
 
     def save(self) -> None:
@@ -134,6 +137,7 @@ class DepsSourcesConfig:
         # first parse the whole config
         json_config = self._to_json(self.config)
         self.file.write_text(json_config, encoding="utf-8")
+        logger.debug("Saved config file %s", self.file)
 
     def show(self, srcnames: tuple[str, ...] = ()) -> None:
         show_conf: DepsConfigType = {"sources": {}}
@@ -168,6 +172,7 @@ class DepsSourcesConfig:
         cannot be collected is not a usable source. Returns None when no
         candidate collects.
         """
+        logger.info("Resolving source candidates")
         validated: list[tuple[str, tuple[str, ...], Collector]] = []
         for candidate in candidates:
             srctype, srcargs = candidate[0], candidate[1:]
@@ -177,10 +182,21 @@ class DepsSourcesConfig:
             validated.append((srctype, srcargs, collector))
 
         for srctype, srcargs, collector in validated:
-            with suppress(Exception):
+            try:
                 # collectors collect lazily
                 deque(collector.collect(), maxlen=0)
-                return srctype, srcargs
+            except Exception as e:  # noqa: BLE001 - uncollectable: try next
+                logger.debug(
+                    "Skipped candidate source: %s (%s)",
+                    " ".join((srctype, *srcargs)),
+                    e,
+                )
+                continue
+            logger.debug(
+                "Picked candidate source: %s",
+                " ".join((srctype, *srcargs)),
+            )
+            return srctype, srcargs
         return None
 
     def add(
@@ -215,6 +231,8 @@ class DepsSourcesConfig:
         (verify, verify_excludes, verify_ignore_version) are forwarded to
         sync() and only apply when sync=True.
         """
+        logger.info("Configuring source %s", srcname)
+
         if all((candidates, srctype)):
             raise ValueError(
                 "srctype is mutually exclusive with candidates",
@@ -243,8 +261,16 @@ class DepsSourcesConfig:
                 self.sources[srcname]["srctype"] == srctype
                 and tuple(self.sources[srcname].get("srcargs", ())) == srcargs
             ):
+                logger.info(
+                    "Source %s already configured, keeping unchanged",
+                    srcname,
+                )
                 keep_existing = True
             else:
+                logger.info(
+                    "Source %s differs, reconfiguring (stored deps dropped)",
+                    srcname,
+                )
                 del self.sources[srcname]
 
         if not keep_existing:
@@ -252,6 +278,11 @@ class DepsSourcesConfig:
             if srcargs:
                 self.sources[srcname]["srcargs"] = srcargs
             self.save()
+            logger.info(
+                "Configured source %s: %s",
+                srcname,
+                " ".join((srctype, *srcargs)),
+            )
 
         if sync:
             self.sync(
@@ -264,8 +295,10 @@ class DepsSourcesConfig:
     def delete(self, srcname: str) -> None:
         if srcname not in self.sources:
             raise ValueError(f"Source {srcname} doesn't exist")
+        logger.info("Deleting source %s", srcname)
         del self.sources[srcname]
         self.save()
+        logger.info("Deleted source %s", srcname)
 
     def iter_sources(
         self,
@@ -327,13 +360,20 @@ class DepsSourcesConfig:
         if verify_ignore_version and not verify:
             raise ValueError("verify_ignore_version must be used with verify")
 
+        logger.info("Syncing sources")
+
         diff: dict[str, dict[str, list[str]]] = {}
         verify_excludes_regs = {re.compile(x) for x in verify_excludes}
 
-        def filter_verify_excludes(req: requirements.Requirement) -> bool:
-            """filter diff output"""
+        def matching_verify_exclude(
+            req: requirements.Requirement,
+        ) -> re.Pattern[str] | None:
+            """The first verify-exclude regex matching req's name, if any."""
             req_name = pep503_normalized_name(req.name)
-            return not any(reg.match(req_name) for reg in verify_excludes_regs)
+            return next(
+                (reg for reg in verify_excludes_regs if reg.match(req_name)),
+                None,
+            )
 
         def version_less_req(
             req: requirements.Requirement,
@@ -348,14 +388,17 @@ class DepsSourcesConfig:
             versionless.specifier = specifiers.SpecifierSet()
             return versionless
 
+        total = 0
+        updated = 0
         for srcname, source in self.iter_sources(srcnames):
+            total += 1
+            srctype = source["srctype"]
+            srcargs = source.get("srcargs", ())
+            logger.info("Syncing source %s", srcname)
             synced_deps = set(
                 map(
                     requirements.Requirement,
-                    self.collect(
-                        source["srctype"],
-                        srcargs=source.get("srcargs", ()),
-                    ),
+                    self.collect(srctype, srcargs=srcargs),
                 ),
             )
 
@@ -364,8 +407,11 @@ class DepsSourcesConfig:
             )
 
             if stored_deps == synced_deps:
+                logger.info("Source %s is in sync", srcname)
                 continue
 
+            updated += 1
+            logger.info("Updated source %s", srcname)
             source["deps"] = tuple(sorted(map(str, synced_deps)))
 
             if not verify:
@@ -397,12 +443,26 @@ class DepsSourcesConfig:
                 ("new_deps", new_deps),
                 ("extra_deps", extra_deps),
             ):
-                filtered_diff_deps = {
-                    req
-                    for req in diff_deps
-                    if filter_verify_excludes(req)
-                    and req not in version_changed_deps
-                }
+                filtered_diff_deps: set[requirements.Requirement] = set()
+                for req in diff_deps:
+                    exclude_match = matching_verify_exclude(req)
+                    if exclude_match is not None:
+                        logger.debug(
+                            "Excluded %s from %s diff: "
+                            "matches verify-exclude '%s'",
+                            req,
+                            srcname,
+                            exclude_match.pattern,
+                        )
+                        continue
+                    if req in version_changed_deps:
+                        logger.debug(
+                            "Excluded %s from %s diff: version-only change",
+                            req,
+                            srcname,
+                        )
+                        continue
+                    filtered_diff_deps.add(req)
 
                 if not filtered_diff_deps:
                     continue
@@ -414,8 +474,16 @@ class DepsSourcesConfig:
         self.save()
 
         if verify and diff:
+            logger.info("%d sources unsynced", len(diff))
             self._show(diff)
             raise DepsUnsyncedError
+
+        logger.info(
+            "Synced %d sources (%d updated, %d in sync)",
+            total,
+            updated,
+            total - updated,
+        )
 
     def depformat(
         self,
@@ -457,10 +525,13 @@ class DepsSourcesConfig:
     ) -> None:
         if depformatextra is not None and depformat is None:
             raise ValueError("depformatextra must be used with depformat")
+        logger.info("Evaluating dependencies")
         deps = set()
+        nsources = 0
         exclude_regexes = {re.compile(x) for x in excludes}
 
-        for _, source in self.iter_sources(srcnames):
+        for srcname, source in self.iter_sources(srcnames):
+            nsources += 1
             # instantiate the collector for its eval_env() marker contribution;
             # the type and args were already validated at config load
             collector = self.validate_collector(
@@ -488,11 +559,31 @@ class DepsSourcesConfig:
                         env = (env or {}) | source_env
                     marker_res = marker.evaluate(env)
                     if not marker_res:
+                        logger.debug(
+                            "Filtered out %s from %s: marker '%s' is false",
+                            parsed_req,
+                            srcname,
+                            marker,
+                        )
                         continue
 
                 # filtering
                 normalized_name = pep503_normalized_name(parsed_req.name)
-                if any(reg.match(normalized_name) for reg in exclude_regexes):
+                exclude_match = next(
+                    (
+                        reg
+                        for reg in exclude_regexes
+                        if reg.match(normalized_name)
+                    ),
+                    None,
+                )
+                if exclude_match is not None:
+                    logger.debug(
+                        "Filtered out %s from %s: matches exclude '%s'",
+                        parsed_req,
+                        srcname,
+                        exclude_match.pattern,
+                    )
                     continue
 
                 # formatting
@@ -511,3 +602,9 @@ class DepsSourcesConfig:
 
         for dep in sorted(deps):
             sys.stdout.write(dep + "\n")
+
+        logger.info(
+            "Evaluated %d dependencies from %d sources",
+            len(deps),
+            nsources,
+        )

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,7 +1,6 @@
 import logging
 import subprocess
 import sys
-import textwrap
 from pathlib import Path
 from typing import Any
 
@@ -137,30 +136,14 @@ def test_help():
     assert result.stderr == b""
 
 
-@pytest.mark.parametrize(
-    "verbose, logging_kwargs",
-    (
-        (False, ("%(levelname)-8s : %(message)s", logging.INFO)),
-        (True, ("%(levelname)-8s : %(name)s : %(message)s", logging.DEBUG)),
-    ),
-    ids=["default", "verbose"],
-)
 @pytest.mark.usefixtures("mock_build_wheel")
-def test_logging(verbose, logging_kwargs, mocker):
-    """Check format and level of logging depending on verbosity"""
+def test_logging_default(mocker):
+    """Check format and level of default logging"""
     m = mocker.patch.object(project_main.logging, "basicConfig")
 
     build_args = ["build"]
-    if verbose:
-        build_args.insert(0, "--verbose")
-
     project_main.main(build_args)
 
-    expected_format, expected_level = logging_kwargs
-    expected_handlers = (
-        (logging.StreamHandler, logging.NOTSET, sys.stdout),
-        (logging.StreamHandler, logging.WARNING, sys.stderr),
-    )
     m.assert_called_once()
     # args
     assert m.call_args.args == ()
@@ -168,54 +151,48 @@ def test_logging(verbose, logging_kwargs, mocker):
     kwargs = m.call_args.kwargs
     assert len(kwargs) == 3
     ## format
-    assert kwargs["format"] == expected_format
+    assert kwargs["format"] == "%(levelname)-8s : %(message)s"
     ## root logger level
-    assert kwargs["level"] == expected_level
+    assert kwargs["level"] == logging.INFO
     ## handlers
     actual_handlers = kwargs["handlers"]
-    assert len(actual_handlers) == 2
-    for expected_handler, actual_handler in zip(
-        expected_handlers,
-        actual_handlers,
-        strict=True,
-    ):
-        expected_type, expected_level, expected_stream = expected_handler
-        assert isinstance(actual_handler, expected_type)
-        assert actual_handler.level == expected_level
-        assert actual_handler.stream == expected_stream
+    assert len(actual_handlers) == 1
+    actual_handler = actual_handlers[0]
+    assert isinstance(actual_handler, logging.StreamHandler)
+    assert actual_handler.level == logging.NOTSET
+    assert actual_handler.stream == sys.stderr
 
 
 @pytest.mark.parametrize(
-    "level,destination",
-    (
-        ("critical", "stderr"),
-        ("error", "stderr"),
-        ("warning", "stderr"),
-        ("info", "stdout"),
-        ("debug", "stdout"),
-    ),
+    "verbose_option",
+    ("-v", "--verbose"),
+    ids=("short", "long"),
 )
-def test_logging_destination(level, destination):
-    code = textwrap.dedent(
-        f"""\
-            import logging
+@pytest.mark.usefixtures("mock_build_wheel")
+def test_logging_verbose(verbose_option, mocker):
+    """Check format and level of verbose logging"""
+    m = mocker.patch.object(project_main.logging, "basicConfig")
 
-            from pyproject_installer import __main__
+    build_args = [verbose_option, "build"]
+    project_main.main(build_args)
 
-            __main__.setup_logging(verbose=True)
-            logging.getLogger().{level}("{level}")
-        """,
-    )
-    cmd = [sys.executable, "-c", code]
-    result = subprocess.run(args=cmd, capture_output=True, check=True)
-    if destination == "stderr":
-        log_out = result.stderr
-        log_no_out = result.stdout
-    else:
-        log_out = result.stdout
-        log_no_out = result.stderr
-    assert log_out.endswith(b" " + level.encode("utf-8") + b"\n")
-    assert log_no_out == b""
+    m.assert_called_once()
+    # args
+    assert m.call_args.args == ()
+    # kwargs
+    kwargs = m.call_args.kwargs
+    assert len(kwargs) == 3
+    ## format
+    assert kwargs["format"] == "%(levelname)-8s : %(name)s : %(message)s"
+    ## root logger level
+    assert kwargs["level"] == logging.DEBUG
+    ## handlers
+    actual_handlers = kwargs["handlers"]
+    assert len(actual_handlers) == 1
+    actual_handler = actual_handlers[0]
+    assert isinstance(actual_handler, logging.StreamHandler)
+    assert actual_handler.level == logging.NOTSET
+    assert actual_handler.stream == sys.stderr
 
 
 def test_build_cli_default(mock_build_wheel):


### PR DESCRIPTION
Route all logging to stderr and reserve stdout for the machine-readable data of deps eval/show/sync --verify (build uses .wheeltracker, so no command outside deps has a stdout data contract). Diagnostics no longer interleave with data at any verbosity, so log levels can reflect intent instead of being kept low just to keep stdout clean.

- setup_logging: single stderr handler; drop the stdout handler and the emit_less_than_warning filter
- each deps command brackets its work with INFO start/finish lines and reports source mutations at INFO; sync also reports each source's result; the display-only show stays silent
- plumbing, no-ops, and per-dependency filter decisions (marker, --exclude, --verify-exclude, --verify-ignore-version) are DEBUG
- README: document -v/--verbose and the stdout=data / stderr=diagnostics split

See for details:
docs/designs/logging_streams_and_status.md

Fixes: https://github.com/stanislavlevin/pyproject_installer/issues/165

## Summary by Sourcery

Route all CLI logging to stderr and add structured logging around deps configuration, sync, and evaluation while documenting the new stderr/stdout split and verbosity behavior.

Enhancements:
- Add info/debug-level logging for deps config load/save, source candidate resolution, and sync/eval filtering decisions.
- Refine deps sync verification logging to explain excluded requirements and summarize sync status per source and overall.

Documentation:
- Document verbose logging behavior and the stderr vs stdout split in README and a new logging design document.

Tests:
- Update logging tests to reflect single-stderr handler behavior and verify verbose-mode configuration.

Chores:
- Clarify contributor guidelines to require stderr-only diagnostics and reserve stdout for machine-readable deps output.