### PR TITLE
feat(deps): add `add --sources` to configure a batch of named sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,19 +437,25 @@ Configure source of Python dependencies. Supported sources: standardized formats
 
 The `metadata` and `metadata_extra` sources build the project's core metadata and cache it in `dist/metadata_cache` under the working directory, so repeated metadata builds for the same source tree (for example several `add ... --sync` calls, or `--candidates` probing followed by a sync) happen only once. Delete that file (or clean `dist/`) to force a rebuild.
 
-> **`<source name>`** (positional)
+There are three ways to add sources, exactly one per call:
+
+- `add <name> <type> [args]` -- one source of an explicit type;
+- `add <name> --candidates LIST` -- one source discovered from an ordered list (the first that collects wins);
+- `add --sources LIST` -- a batch of explicitly named sources, each `<name> <type> [args ...]`.
+
+> **`<source name>`** (positional, optional)
 >
-> Source name.
+> Source name. Omit when using `--sources`.
 
 > **`<source type>`** (positional, optional)
 >
-> Omit when using `--candidates`.
+> Omit when using `--candidates` or `--sources`.
 >
 > *Choices:* `pep517`, `pep518`, `pep735`, `metadata`, `metadata_extra`, `pip_reqfile`, `poetry`, `tox`, `hatch`, `pdm`, `pipenv`
 
 > **`<source-specific options>`** (positional, variadic)
 >
-> Omit when using `--candidates`.
+> Omit when using `--candidates` or `--sources`.
 >
 > Specific configuration options for source.
 >
@@ -464,6 +470,16 @@ The `metadata` and `metadata_extra` sources build the project's core metadata an
 > *Default:* disabled
 >
 > *Example:* `python -m pyproject_installer deps add check --candidates 'pep735 test;pep735 tests;pip_reqfile test-requirements.txt' --reconfigure --sync --verify`
+
+> **`--sources LIST`**
+>
+> Add a batch of explicitly named sources in one call (the additive counterpart of `--candidates`). `LIST` is a `;`-separated string whose entries are each `<name> <type> [args ...]` (a positional `name type [args]` per entry). The entries are handled one at a time, in order: each is configured exactly as a regular `add <name> <type> [args]` (`--reconfigure` applies per entry), and with `--sync` it is synced and verified before the next, so one call equals running `add <name> <type> [args] --reconfigure --sync --verify` once per entry in a single process. A malformed list is a usage error, not a silent skip: an empty list, an entry without a type, an unknown type, or a name repeated within the list; a wrong argument count for a type is reported when that entry is configured (the same error as an explicit `add`).
+>
+> With `--verify`, the run stops at the first source that is out of sync and exits with code 4; the entries after it are not reached, so a failed run leaves the earlier entries configured and synced and the later ones untouched. Run without `--verify` to configure and sync the whole list in one pass; `--verify` is a check and keeps stopping at the first out-of-sync source. `--sources` takes no positional name/type/args and is mutually exclusive with `--candidates`; because there are no positionals, `--sources` and the verify options may be given in any order.
+>
+> *Default:* disabled
+>
+> *Example:* `python -m pyproject_installer deps add --sources 'check_pep735 pep735 test;check_meta metadata_extra tests' --reconfigure --sync --verify`
 
 > **`--reconfigure`**
 >
@@ -524,6 +540,12 @@ python -m pyproject_installer deps add check pipenv Pipfile packages
 # reconcile and verify it in one process
 python -m pyproject_installer deps add check \
     --candidates 'pep735 test;pep735 tests;pip_reqfile test-requirements.txt;metadata_extra tests' \
+    --reconfigure --sync --verify
+
+# add a declared set of named sources in one process, reconciling and
+# verifying each in turn (stops at the first that is out of sync)
+python -m pyproject_installer deps add \
+    --sources 'check_pep735 pep735 test;check_meta metadata_extra tests' \
     --reconfigure --sync --verify
 ```
 

--- a/docs/designs/deps_add_sources.md
+++ b/docs/designs/deps_add_sources.md
@@ -1,0 +1,98 @@
+## Abstract
+`deps add --sources LIST` adds a batch of explicitly named sources in
+one `add` call, from a `;`-separated list of `<name> <type> [args ...]`
+entries instead of a single positional `name type [args]` per source. With
+`--reconfigure` and `--sync`, one call configures, syncs and verifies a
+whole set of declared sources in a single process.
+
+It is the additive sibling of `--candidates`: `--candidates` discovers
+**one** source from an ordered list (first that collects wins);
+`--sources` adds **all** of an explicit, pre-named list.
+
+## Motivation
+A caller may need to declare several dependency sources beyond the one
+autodiscovery finds (a second PEP 735 group, a tox testenv) and
+configure, sync and verify all of them. One source per `add` means one
+call — one process spawn, ~150 ms — per source, carrying N command
+strings instead of just the source list. One `add --sources` call
+reduces this to a single process carrying just `<name> <type> args;...`,
+mirroring `--candidates` for the additive case discovery does not cover.
+
+## Specification
+
+### `--sources LIST`
+`LIST` is a `;`-separated string; each entry is `<name> <type>
+[args ...]` (space-separated). Example:
+
+```
+'src_a pep735 group_a;src_b tox tox.ini env_b'
+```
+
+Parsing mirrors `--candidates`: entries are split on whitespace, blanks
+dropped, and surrounding/repeated whitespace and a trailing `;` are
+harmless. A malformed list is a usage error (`WRONG_USAGE`, 2), not a
+skipped entry: an empty/whitespace/`;`-only value (no entries), an entry
+with fewer than two tokens (name without a type), an unknown type, or a
+name repeated within the list. A wrong argument count is *not* a
+parse-time error: like `--candidates` and the single-source `add`, it is
+checked against the collector when that entry is configured, raising
+`DepsSourcesConfigError` (not `WRONG_USAGE`).
+
+### Per-entry cycle
+Entries are handled one at a time, in list order: each is configured,
+and with `--sync` synced and verified, before the next — so `--sources`
+equals running `add <entry> --reconfigure --sync --verify` once per
+entry in one process (sharing `--verify-exclude` /
+`--verify-ignore-version`). Configuring behaves exactly as a regular
+`add <name> <type> [args]`: without `--reconfigure` an existing name
+errors (`Source <name> already exists`); with it the source is kept when
+its type and args match, or replaced (stored deps dropped) when they
+differ.
+
+Nothing is collected at add time — `--sources` is a declaration, not a
+discovery; configuring only records `type`/`args`. With `--verify`, the
+first source that is out of sync raises `DepsUnsyncedError` and exits
+`SYNC_VERIFY_ERROR` (4); later entries are never reached — not synced,
+not configured. (A freshly added or replaced source has no stored deps,
+so its first `--verify` is always out of sync.) A source that cannot be
+collected fails the same way at its sync step (the normal collect
+failure), never a silent skip — so there is no `--sources` analog of the
+no-candidate exit (5). A failed run leaves earlier entries configured
+and synced and later ones untouched; running without `--verify`
+configures and syncs the whole list in one pass (`--verify` is a check
+and keeps stopping at the first out-of-sync entry).
+
+Because there are no positionals, the `name`-before-`--verify-exclude`
+ordering caveat does not arise. Programmatic API:
+`DepsSourcesConfig.add(..., sources=(...))`, where `sources` is an
+ordered tuple of `(srcname, srctype, *srcargs)`, mutually exclusive with
+`srcname`/`srctype`/`candidates`; `add()` runs its single-source code
+per entry, so the first `DepsUnsyncedError` stops the rest.
+
+### Mutual exclusion
+`--sources` carries its own names, takes **no positional arguments**,
+and is mutually exclusive with the positional `name`/`type`/`args` and
+with `--candidates`. The positional `name` becomes optional; exactly one
+mode must be given (more than one, or `--sources` with a positional, is
+`WRONG_USAGE`, 2):
+
+- `add <name> <type> [args]` — one explicit source;
+- `add <name> --candidates LIST` — one discovered source;
+- `add --sources LIST` — a batch of explicit named sources.
+
+## Example
+
+```
+python -m pyproject_installer deps add \
+    --sources 'src_a pep735 group_a;src_b metadata_extra extra_b' \
+    --reconfigure --sync --verify --verify-exclude 'excluded-dep'
+```
+
+- neither configured → first added and synced, out of sync on verify →
+  exit 4; second never reached;
+- both recorded with the same type/args → kept; `--verify` passes if
+  neither's deps changed;
+- one now differing (type or args) → replaced, deps dropped, out of sync
+  → exit 4;
+- one that cannot be collected → collect failure at sync, an error, not
+  skipped.

--- a/src/pyproject_installer/__main__.py
+++ b/src/pyproject_installer/__main__.py
@@ -90,13 +90,28 @@ def deps(
             parser.error("depformatextra option must be used with depformat")
 
         if hasattr(args, "candidates"):
-            if all((args.candidates, args.srctype)):
-                parser.error(
-                    "srctype positional is mutually exclusive "
-                    "with --candidates",
-                )
-            if not any((args.candidates, args.srctype)):
-                parser.error("either srctype or --candidates is required")
+            if args.sources is not None:
+                if any((args.srcname, args.srctype, args.srcargs)):
+                    parser.error("--sources takes no positional name/type/args")
+                if args.candidates is not None:
+                    parser.error(
+                        "--sources is mutually exclusive with --candidates",
+                    )
+            else:
+                if args.srcname is None:
+                    parser.error(
+                        "srcname positional is required with --candidates or "
+                        "srctype",
+                    )
+                if all((args.candidates, args.srctype)):
+                    parser.error(
+                        "srctype positional is mutually exclusive "
+                        "with --candidates",
+                    )
+                if not any((args.candidates, args.srctype)):
+                    parser.error(
+                        "either srctype or --candidates is required",
+                    )
 
         if (
             hasattr(args, "sync")
@@ -256,6 +271,43 @@ def parse_candidates(value: str) -> tuple[tuple[str, ...], ...]:
                 f"(choose from {', '.join(SUPPORTED_COLLECTORS)})",
             )
     return candidates
+
+
+def parse_sources(value: str) -> tuple[tuple[str, ...], ...]:
+    """Parse a ;-separated --sources list into (name, type, *args) tuples.
+
+    Each ;-separated entry is split on whitespace into a name, a type and
+    the type's args, and blank entries are dropped; surrounding or repeated
+    whitespace and a trailing ';' are therefore harmless. A malformed list
+    is rejected as a usage error rather than silently skipped: it is an
+    error when no entries are left after dropping blanks (an empty,
+    whitespace-only, or ';'-only value), when an entry has fewer than two
+    tokens (a name without a type), when an entry's type is not a known
+    collector, or when a name is repeated within the list.
+    """
+    sources = tuple(
+        tuple(parts) for entry in value.split(";") if (parts := entry.split())
+    )
+    if not sources:
+        raise argparse.ArgumentTypeError(f"no sources parsed from {value!r}")
+    seen: set[str] = set()
+    for srcname, *rest in sources:
+        if not rest:
+            raise argparse.ArgumentTypeError(
+                f"missing source type for {srcname!r}",
+            )
+        srctype = rest[0]
+        if srctype not in SUPPORTED_COLLECTORS:
+            raise argparse.ArgumentTypeError(
+                f"invalid source type for {srcname!r}: {srctype!r} "
+                f"(choose from {', '.join(SUPPORTED_COLLECTORS)})",
+            )
+        if srcname in seen:
+            raise argparse.ArgumentTypeError(
+                f"duplicate source name in a given list: {srcname!r}",
+            )
+        seen.add(srcname)
+    return sources
 
 
 def convert_config_settings(value: str | None) -> dict[str, Any] | None:
@@ -486,7 +538,9 @@ def deps_subparsers(parser: argparse.ArgumentParser) -> None:
         subparser_add,
         destname,
         destname,
-        help="source name",
+        nargs="?",
+        default=None,
+        help="source name (omit when using --sources)",
     )
 
     destname = "srctype"
@@ -497,7 +551,7 @@ def deps_subparsers(parser: argparse.ArgumentParser) -> None:
         nargs="?",
         default=None,
         choices=SUPPORTED_COLLECTORS,
-        help="source type (omit when using --candidates)",
+        help="source type (omit when using --candidates or --sources)",
     )
 
     destname = "srcargs"
@@ -508,7 +562,7 @@ def deps_subparsers(parser: argparse.ArgumentParser) -> None:
         nargs="*",
         help=(
             "specific configuration options for source "
-            "(omit when using --candidates; default: [])"
+            "(omit when using --candidates or --sources; default: [])"
         ),
     )
 
@@ -527,6 +581,23 @@ def deps_subparsers(parser: argparse.ArgumentParser) -> None:
             "picked and supplies the recorded type/args. Mutually exclusive "
             "with the positional type/args; the source name is the only "
             "positional."
+        ),
+    )
+
+    destname = "sources"
+    add_deps_argument(
+        subparser_add,
+        destname,
+        f"--{destname}",
+        type=parse_sources,
+        default=None,
+        metavar="LIST",
+        help=(
+            "Add a batch of explicitly named sources from a ';'-separated "
+            "list of '<name> <type> [args ...]' entries, each configured "
+            "(and, with --sync, synced and verified) in turn. Takes no "
+            "positional name/type/args and is mutually exclusive with "
+            "--candidates."
         ),
     )
 

--- a/src/pyproject_installer/deps_cmd/deps_config.py
+++ b/src/pyproject_installer/deps_cmd/deps_config.py
@@ -201,11 +201,12 @@ class DepsSourcesConfig:
 
     def add(
         self,
-        srcname: str,
+        srcname: str | None = None,
         srctype: str | None = None,
         srcargs: tuple[str, ...] = (),
         *,
         candidates: tuple[tuple[str, ...], ...] | None = None,
+        sources: tuple[tuple[str, ...], ...] | None = None,
         reconfigure: bool = False,
         sync: bool = False,
         verify: bool = False,
@@ -230,7 +231,39 @@ class DepsSourcesConfig:
         replaced), sync it in the same process. The verify options
         (verify, verify_excludes, verify_ignore_version) are forwarded to
         sync() and only apply when sync=True.
+
+        sources: an ordered tuple of (srcname, srctype, *srcargs) tuples for
+        adding a batch in one call. It cannot be combined with single source
+        configuration or candidates. Each entry is configured -- and, when
+        sync=True, synced and optionally verified -- in turn via this same
+        single-source path, so the first DepsUnsyncedError stops the rest (later
+        entries are left unconfigured).
         """
+        if sources is not None:
+            if any((srcname, srctype, srcargs, candidates)):
+                raise ValueError(
+                    "sources is mutually exclusive with "
+                    "single source configuration or candidates",
+                )
+            for src_name, src_type, *src_args in sources:
+                self.add(
+                    src_name,
+                    src_type,
+                    tuple(src_args),
+                    reconfigure=reconfigure,
+                    sync=sync,
+                    verify=verify,
+                    verify_excludes=verify_excludes,
+                    verify_ignore_version=verify_ignore_version,
+                )
+            return
+
+        if srcname is None:
+            raise ValueError(
+                "source name is required with --candidates or single source "
+                "configuration",
+            )
+
         logger.info("Configuring source %s", srcname)
 
         if all((candidates, srctype)):

--- a/tests/unit/test_deps/test_deps_add.py
+++ b/tests/unit/test_deps/test_deps_add.py
@@ -816,3 +816,273 @@ def test_config_add_candidates_with_srctype_errors(
             candidates=candidates,
         )
     assert not depsconfig_path.exists()
+
+
+def test_config_add_sources_batch(depsconfig_path):
+    """add(sources=...) configures every entry, in list order."""
+
+    action = "add"
+    sources = (("foo", "metadata"), ("bar", "pip_reqfile", "r.txt"))
+
+    deps_command(action, depsconfig_path, sources=sources)
+
+    actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))
+    expected_conf = {
+        "sources": {
+            "foo": {"srctype": "metadata"},
+            "bar": {"srctype": "pip_reqfile", "srcargs": ["r.txt"]},
+        },
+    }
+    assert actual_conf == expected_conf
+
+
+def test_config_add_sources_with_srcname_errors(depsconfig_path):
+    """sources is mutually exclusive with a positional srcname."""
+
+    expected_err = (
+        r"^sources is mutually exclusive with single source configuration "
+        r"or candidates$"
+    )
+    with pytest.raises(ValueError, match=expected_err):
+        deps_command(
+            "add",
+            depsconfig_path,
+            srcname="foo",
+            sources=(("bar", "metadata"),),
+        )
+    assert not depsconfig_path.exists()
+
+
+def test_config_add_sources_with_candidates_errors(depsconfig_path):
+    """sources is mutually exclusive with candidates."""
+
+    expected_err = (
+        r"^sources is mutually exclusive with single source configuration "
+        r"or candidates$"
+    )
+    with pytest.raises(ValueError, match=expected_err):
+        deps_command(
+            "add",
+            depsconfig_path,
+            candidates=(("pep735", "test"),),
+            sources=(("bar", "metadata"),),
+        )
+    assert not depsconfig_path.exists()
+
+
+def test_config_add_sources_sync(depsconfig_path, mock_collector):
+    """sources with sync=True configures and syncs every entry."""
+
+    new_reqs = ["bar"]
+    sources = (("foo", "mock_collector"), ("baz", "mock_collector"))
+
+    mock_collector(new_reqs)
+    deps_command("add", depsconfig_path, sources=sources, sync=True)
+
+    actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))
+    expected_conf = {
+        "sources": {
+            "foo": {"srctype": "mock_collector", "deps": new_reqs},
+            "baz": {"srctype": "mock_collector", "deps": new_reqs},
+        },
+    }
+    assert actual_conf == expected_conf
+
+
+def test_config_add_sources_sync_verify_fail_fast(
+    depsconfig_path,
+    mock_collector,
+):
+    """verify stops at the first out-of-sync entry; later ones untouched.
+
+    Both entries are freshly added (no stored deps), so the first verify
+    is out of sync and raises -- the second entry is never configured.
+    """
+
+    new_reqs = ["bar"]
+    sources = (("foo", "mock_collector"), ("baz", "mock_collector"))
+
+    mock_collector(new_reqs)
+    with pytest.raises(DepsUnsyncedError):
+        deps_command(
+            "add",
+            depsconfig_path,
+            sources=sources,
+            sync=True,
+            verify=True,
+        )
+
+    actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))
+    expected_conf = {
+        "sources": {"foo": {"srctype": "mock_collector", "deps": new_reqs}},
+    }
+    assert actual_conf == expected_conf
+
+
+def test_config_add_sources_verify_keeps_earlier_skips_later(
+    depsconfig,
+    mock_collector,
+):
+    """A later out-of-sync entry stops the run: an earlier in-sync entry
+    stays configured, the out-of-sync entry is configured and synced, and the
+    entry after it is never reached.
+
+    'a' is already configured with deps that match what the collector
+    yields, so its verify passes; 'b' is fresh and is out of sync.
+    """
+
+    reqs = ["bar"]
+    input_conf = {
+        "sources": {"a": {"srctype": "mock_collector", "deps": reqs}},
+    }
+    depsconfig_path = depsconfig(json.dumps(input_conf))
+    sources = (
+        ("a", "mock_collector"),
+        ("b", "mock_collector"),
+        ("c", "mock_collector"),
+    )
+
+    mock_collector(reqs)
+    with pytest.raises(DepsUnsyncedError):
+        deps_command(
+            "add",
+            depsconfig_path,
+            sources=sources,
+            reconfigure=True,
+            sync=True,
+            verify=True,
+        )
+
+    actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))
+    expected_conf = {
+        "sources": {
+            "a": {"srctype": "mock_collector", "deps": reqs},
+            "b": {"srctype": "mock_collector", "deps": reqs},
+        },
+    }
+    assert actual_conf == expected_conf
+
+
+def test_config_add_sources_existing_without_reconfigure_stops(depsconfig):
+    """An existing name without reconfigure stops the run; earlier entries
+    are already written (partial), exactly as a per-entry add would do."""
+
+    input_conf = {
+        "sources": {"foo": {"srctype": "metadata", "deps": ["old_req"]}},
+    }
+    depsconfig_path = depsconfig(json.dumps(input_conf))
+    sources = (("bar", "metadata"), ("foo", "metadata"))
+
+    with pytest.raises(ValueError, match=r"^Source foo already exists"):
+        deps_command("add", depsconfig_path, sources=sources)
+
+    actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))
+    expected_conf = {
+        "sources": {
+            "foo": {"srctype": "metadata", "deps": ["old_req"]},
+            "bar": {"srctype": "metadata"},
+        },
+    }
+    assert actual_conf == expected_conf
+
+
+def test_config_add_sources_reconfigure_replaces(depsconfig):
+    """reconfigure applies per entry: a differing entry is replaced."""
+
+    input_conf = {
+        "sources": {"foo": {"srctype": "metadata", "deps": ["old"]}},
+    }
+    depsconfig_path = depsconfig(json.dumps(input_conf))
+    sources = (("foo", "pip_reqfile", "r.txt"),)
+
+    deps_command("add", depsconfig_path, sources=sources, reconfigure=True)
+
+    actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))
+    expected_conf = {
+        "sources": {"foo": {"srctype": "pip_reqfile", "srcargs": ["r.txt"]}},
+    }
+    assert actual_conf == expected_conf
+
+
+def test_config_add_sources_bad_args_stops(depsconfig_path):
+    """A wrong argument count is checked per entry when it is configured;
+    earlier entries are already written."""
+
+    sources = (("foo", "metadata"), ("bar", "pip_reqfile"))
+
+    expected_err = r"^Unsupported arguments of collector pip_reqfile"
+    with pytest.raises(DepsSourcesConfigError, match=expected_err):
+        deps_command("add", depsconfig_path, sources=sources)
+
+    actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))
+    expected_conf = {"sources": {"foo": {"srctype": "metadata"}}}
+    assert actual_conf == expected_conf
+
+
+def test_config_add_sources_sync_collect_failure_stops(
+    depsconfig_path,
+    pip_reqfile,
+):
+    """A source that cannot be collected fails at its sync step and stops the
+    run: the earlier entry is synced, the failing entry stays configured with
+    no deps, and the entry after it is never reached."""
+
+    reqfile = pip_reqfile("bar\n")
+    sources = (
+        ("a", "pip_reqfile", str(reqfile)),
+        ("b", "pip_reqfile", "missing.txt"),
+        ("c", "metadata"),
+    )
+
+    with pytest.raises(FileNotFoundError):
+        deps_command("add", depsconfig_path, sources=sources, sync=True)
+
+    actual_conf = json.loads(depsconfig_path.read_text(encoding="utf-8"))
+    expected_conf = {
+        "sources": {
+            "a": {
+                "srctype": "pip_reqfile",
+                "srcargs": [str(reqfile)],
+                "deps": ["bar"],
+            },
+            "b": {"srctype": "pip_reqfile", "srcargs": ["missing.txt"]},
+        },
+    }
+    assert actual_conf == expected_conf
+
+
+@pytest.mark.parametrize(
+    "extra_kwargs",
+    ({"srctype": "metadata"}, {"srcargs": ("x",)}),
+    ids=("srctype", "srcargs"),
+)
+def test_config_add_sources_with_single_source_args_errors(
+    depsconfig_path,
+    extra_kwargs,
+):
+    """sources cannot be combined with srctype or srcargs either."""
+
+    expected_err = (
+        r"^sources is mutually exclusive with single source configuration "
+        r"or candidates$"
+    )
+    with pytest.raises(ValueError, match=expected_err):
+        deps_command(
+            "add",
+            depsconfig_path,
+            sources=(("bar", "metadata"),),
+            **extra_kwargs,
+        )
+    assert not depsconfig_path.exists()
+
+
+def test_config_add_requires_srcname_or_sources(depsconfig_path):
+    """add() with neither a srcname nor sources is an error."""
+
+    expected_err = (
+        r"^source name is required with --candidates or single source "
+        r"configuration"
+    )
+    with pytest.raises(ValueError, match=expected_err):
+        deps_command("add", depsconfig_path)
+    assert not depsconfig_path.exists()

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -106,6 +106,7 @@ DEFAULT_DEPS_ADD_CLI_KWARGS: dict[str, Any] = {
     "srctype": None,
     "srcargs": [],
     "candidates": None,
+    "sources": None,
     "reconfigure": False,
     "sync": False,
     "verify": False,
@@ -1880,6 +1881,28 @@ def test_deps_cli_add_sync_verify_drift_exits(mock_deps_command):
     assert exc.value.code == ExitCodes.SYNC_VERIFY_ERROR
 
 
+def test_deps_cli_add_sources_sync_verify_drift_exits(mock_deps_command):
+    """Run deps add --sources with sync and failed verify
+
+    - mock deps_command to raise DepsUnsyncedError (an out-of-sync entry)
+    - check the --sources path maps it to the same exit code
+    """
+    action = "add"
+    mock_deps_command.side_effect = project_main.DepsUnsyncedError
+    deps_args = [
+        "deps",
+        action,
+        "--sources",
+        "a metadata;b metadata",
+        "--sync",
+        "--verify",
+    ]
+
+    with pytest.raises(SystemExit) as exc:
+        project_main.main(deps_args)
+    assert exc.value.code == ExitCodes.SYNC_VERIFY_ERROR
+
+
 @pytest.mark.parametrize(
     "verify_subcommand",
     (["--verify-exclude", "x$"], ["--verify-ignore-version"]),
@@ -2131,6 +2154,219 @@ def test_deps_cli_add_candidates_no_candidate_reports_and_exits(
         project_main.main(deps_args)
     assert exc.value.code == ExitCodes.ADD_NO_CANDIDATE_ERROR
     assert expected_message in caplog.text
+
+
+def test_deps_cli_add_sources(mock_deps_command):
+    """Run deps add with --sources
+
+    - the ;-list is parsed to (name, type, *args) tuples
+    - no positional name/type (srcname is None)
+    """
+    action = "add"
+    depsconfig = Path.cwd() / project_main.DEFAULT_CONFIG_NAME
+    deps_args = [
+        "deps",
+        action,
+        "--sources",
+        "a metadata;b pip_reqfile r.txt",
+    ]
+
+    r_args = (action, Path(depsconfig))
+    r_kwargs = dict(
+        DEFAULT_DEPS_ADD_CLI_KWARGS,
+        srcname=None,
+        sources=(("a", "metadata"), ("b", "pip_reqfile", "r.txt")),
+    )
+
+    project_main.main(deps_args)
+    mock_deps_command.assert_called_once_with(*r_args, **r_kwargs)
+
+
+def test_deps_cli_add_sources_lenient_parsing(mock_deps_command):
+    """Run deps add with a sloppy but valid --sources list
+
+    - blank entries (trailing ';', whitespace-only) are dropped
+    - a multi-arg entry is split into (name, type, *args)
+    """
+    action = "add"
+    depsconfig = Path.cwd() / project_main.DEFAULT_CONFIG_NAME
+    deps_args = [
+        "deps",
+        action,
+        "--sources",
+        " a metadata ; b tox tox.ini testenv ;; c pip_reqfile r.txt ; ",
+    ]
+
+    r_args = (action, Path(depsconfig))
+    r_kwargs = dict(
+        DEFAULT_DEPS_ADD_CLI_KWARGS,
+        srcname=None,
+        sources=(
+            ("a", "metadata"),
+            ("b", "tox", "tox.ini", "testenv"),
+            ("c", "pip_reqfile", "r.txt"),
+        ),
+    )
+
+    project_main.main(deps_args)
+    mock_deps_command.assert_called_once_with(*r_args, **r_kwargs)
+
+
+def test_deps_cli_add_sources_reconfigure_sync_verify(mock_deps_command):
+    """Run deps add --sources composed with --reconfigure/--sync/--verify
+
+    - check all options are forwarded with the parsed sources
+    """
+    action = "add"
+    depsconfig = Path.cwd() / project_main.DEFAULT_CONFIG_NAME
+    deps_args = [
+        "deps",
+        action,
+        "--sources",
+        "a metadata;b metadata",
+        "--reconfigure",
+        "--sync",
+        "--verify",
+        "--verify-exclude",
+        "excluded-dep",
+    ]
+
+    r_args = (action, Path(depsconfig))
+    r_kwargs = dict(
+        DEFAULT_DEPS_ADD_CLI_KWARGS,
+        srcname=None,
+        sources=(("a", "metadata"), ("b", "metadata")),
+        reconfigure=True,
+        sync=True,
+        verify=True,
+        verify_excludes=["excluded-dep"],
+    )
+
+    project_main.main(deps_args)
+    mock_deps_command.assert_called_once_with(*r_args, **r_kwargs)
+
+
+@pytest.mark.parametrize(
+    "positionals",
+    (["foo"], ["foo", "metadata"], ["foo", "metadata", "x"]),
+    ids=("name", "name-type", "name-type-args"),
+)
+def test_deps_cli_add_sources_with_positional_is_error(
+    mock_deps_command,
+    capsys,
+    positionals,
+):
+    """Run deps add with --sources and any positional -> usage error"""
+    action = "add"
+    deps_args = ["deps", action, *positionals, "--sources", "a metadata"]
+
+    with pytest.raises(SystemExit) as exc:
+        project_main.main(deps_args)
+    assert exc.value.code == ExitCodes.WRONG_USAGE
+    expected_message = "--sources takes no positional name/type/args"
+    assert expected_message in capsys.readouterr().err
+    mock_deps_command.assert_not_called()
+
+
+def test_deps_cli_add_sources_with_candidates_is_error(
+    mock_deps_command,
+    capsys,
+):
+    """Run deps add with both --sources and --candidates -> usage error"""
+    action = "add"
+    deps_args = [
+        "deps",
+        action,
+        "--sources",
+        "a metadata",
+        "--candidates",
+        "pep735 test",
+    ]
+
+    with pytest.raises(SystemExit) as exc:
+        project_main.main(deps_args)
+    assert exc.value.code == ExitCodes.WRONG_USAGE
+    expected_message = "--sources is mutually exclusive with --candidates"
+    assert expected_message in capsys.readouterr().err
+    mock_deps_command.assert_not_called()
+
+
+def test_deps_cli_add_sources_empty_is_error(mock_deps_command, capsys):
+    """Run deps add with an empty --sources list -> usage error"""
+    action = "add"
+    sources = " ; "
+    deps_args = ["deps", action, "--sources", sources]
+
+    with pytest.raises(SystemExit) as exc:
+        project_main.main(deps_args)
+    assert exc.value.code == ExitCodes.WRONG_USAGE
+    expected_message = f"no sources parsed from {sources!r}"
+    assert expected_message in capsys.readouterr().err
+    mock_deps_command.assert_not_called()
+
+
+def test_deps_cli_add_sources_name_without_type_is_error(
+    mock_deps_command,
+    capsys,
+):
+    """Run deps add with an entry that has only a name -> usage error"""
+    action = "add"
+    deps_args = ["deps", action, "--sources", "a metadata;loner"]
+
+    with pytest.raises(SystemExit) as exc:
+        project_main.main(deps_args)
+    assert exc.value.code == ExitCodes.WRONG_USAGE
+    expected_message = "missing source type for 'loner'"
+    assert expected_message in capsys.readouterr().err
+    mock_deps_command.assert_not_called()
+
+
+def test_deps_cli_add_sources_unknown_type_is_error(mock_deps_command, capsys):
+    """Run deps add with an unknown type in --sources -> usage error"""
+    action = "add"
+    deps_args = ["deps", action, "--sources", "a metadata;b bogus"]
+
+    with pytest.raises(SystemExit) as exc:
+        project_main.main(deps_args)
+    assert exc.value.code == ExitCodes.WRONG_USAGE
+    expected_message = "invalid source type for 'b': 'bogus'"
+    assert expected_message in capsys.readouterr().err
+    mock_deps_command.assert_not_called()
+
+
+def test_deps_cli_add_sources_duplicate_name_is_error(
+    mock_deps_command,
+    capsys,
+):
+    """Run deps add with a name repeated within --sources -> usage error"""
+    action = "add"
+    deps_args = ["deps", action, "--sources", "a metadata;a pip_reqfile r.txt"]
+
+    with pytest.raises(SystemExit) as exc:
+        project_main.main(deps_args)
+    assert exc.value.code == ExitCodes.WRONG_USAGE
+    expected_message = "duplicate source name in a given list: 'a'"
+    assert expected_message in capsys.readouterr().err
+    mock_deps_command.assert_not_called()
+
+
+def test_deps_cli_add_requires_name(mock_deps_command, capsys):
+    """Run deps add without a name and without --sources -> usage error
+
+    The name positional is optional now (omitted with --sources), so a
+    missing name in the positional/candidates modes is caught here.
+    """
+    action = "add"
+    deps_args = ["deps", action, "--candidates", "pep735 test"]
+
+    with pytest.raises(SystemExit) as exc:
+        project_main.main(deps_args)
+    assert exc.value.code == ExitCodes.WRONG_USAGE
+    expected_message = (
+        "srcname positional is required with --candidates or srctype"
+    )
+    assert expected_message in capsys.readouterr().err
+    mock_deps_command.assert_not_called()
 
 
 def test_deps_cli_delete_help(capsys):


### PR DESCRIPTION
Downstream packaging may declare several test-dependency sources beyond the one autodiscovery finds (a second PEP 735 group, a tox testenv) and must configure, sync and verify all of them. With one source per `add` that is one process spawn per source, and whatever accumulates the calls carries full command strings rather than just the data. `--sources` does the whole set in one process.

It is the additive counterpart of `--candidates`: where `--candidates` discovers one source from an ordered list, `--sources` adds all of an explicit, pre-named list. Its argument is a `;`-separated string of `<name> <type> [args ...]` entries, validated up front (an empty list, a name without a type, an unknown type, or a name repeated within the list is a usage error) and then handled one at a time, in order: each entry is configured exactly as a regular `add <name> <type> [args]` (`--reconfigure` applies per entry), and with `--sync` it is synced and verified before the next. A wrong argument count is reported when its entry is configured, the same error as an explicit `add`.

With `--verify` the run is fail-fast: the first source that is out of sync raises and exits 4, and the entries after it are never reached, so a failed run leaves the earlier entries configured and the later ones untouched; running without `--verify` configures and syncs the whole list in one pass. `--sources` takes no positional name/type/args and is mutually exclusive with `--candidates`; the `add` name positional becomes optional.

Fixes: https://github.com/stanislavlevin/pyproject_installer/issues/169

## Summary by Sourcery

Introduce a batch-oriented deps add mode that accepts multiple named sources in a single invocation and wires it through the CLI, configuration layer, and documentation.

New Features:
- Add a --sources option to the deps add CLI to configure a batch of explicitly named sources from a ';'-separated list.
- Extend the deps configuration API to support adding multiple sources in one call via a sources parameter, processed sequentially with existing sync and verify behaviour.

Enhancements:
- Relax deps add positional arguments so the source name and type become optional when using batch or candidate-based modes, with clearer mutual-exclusion and validation rules.
- Improve error handling and messaging for invalid combinations of add options and malformed source lists, including duplicate names and unknown types in --sources.

Documentation:
- Document the new deps add --sources option, its semantics, and examples in the README, and add a design document describing its behaviour and motivation.

Tests:
- Add unit tests for deps add --sources covering parsing, mutual exclusion with positionals and --candidates, per-entry sync/verify behaviour, and failure modes at both the config and CLI layers.