### PR TITLE
feat(deps): report unsynced sources as a self-sufficient diagnostic

### DIFF
--- a/src/pyproject_installer/__main__.py
+++ b/src/pyproject_installer/__main__.py
@@ -136,9 +136,8 @@ def deps(
         except DepsUnsyncedError:
             # sync --verify error
             sys.exit(ExitCodes.SYNC_VERIFY_ERROR)
-        except DepsNoCandidateError as e:
-            # add --candidates with no candidate picked: report and exit
-            logger.info("%s", e)
+        except DepsNoCandidateError:
+            # add --candidates with no candidate picked
             sys.exit(ExitCodes.ADD_NO_CANDIDATE_ERROR)
 
     return wrapped

--- a/src/pyproject_installer/deps_cmd/deps_config.py
+++ b/src/pyproject_installer/deps_cmd/deps_config.py
@@ -150,6 +150,9 @@ class DepsSourcesConfig:
 
     def _show(self, conf: Mapping[str, Any]) -> None:
         sys.stdout.write(self._to_json(conf))
+        # flush data (stdout) so it precedes any later diagnostics (stderr) in
+        # a merged stream, regardless of stdout block-buffering when piped
+        sys.stdout.flush()
 
     @property
     def sources(self) -> dict[str, DepsConfigSourceSpec]:
@@ -273,9 +276,16 @@ class DepsSourcesConfig:
 
         if candidates is not None:
             if (picked := self._resolve_candidate(candidates)) is None:
+                logger.error(
+                    "Autodiscovery failed for source %s: no candidate "
+                    "source could be collected (tried: %s)",
+                    srcname,
+                    ", ".join(" ".join(c) for c in candidates),
+                )
                 raise DepsNoCandidateError(
                     f"No candidate source matched for {srcname}",
                 )
+
             srctype, srcargs = picked
         elif srctype is None:
             raise ValueError("add requires either srctype or candidates")
@@ -509,6 +519,13 @@ class DepsSourcesConfig:
         if verify and diff:
             logger.info("%d sources unsynced", len(diff))
             self._show(diff)
+            logger.error(
+                "Dependencies of %d source(s) changed since last check: %s.\n"
+                'The configuration was synced and saved into "%s"',
+                len(diff),
+                ", ".join(sorted(diff)),
+                self.file,
+            )
             raise DepsUnsyncedError
 
         logger.info(
@@ -635,6 +652,9 @@ class DepsSourcesConfig:
 
         for dep in sorted(deps):
             sys.stdout.write(dep + "\n")
+        # flush data (stdout) so it precedes the diagnostic below (stderr) in a
+        # merged stream, regardless of stdout block-buffering when piped
+        sys.stdout.flush()
 
         logger.info(
             "Evaluated %d dependencies from %d sources",

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -2132,28 +2132,20 @@ def test_deps_cli_add_candidates_unknown_type_is_error(
 
 def test_deps_cli_add_candidates_no_candidate_reports_and_exits(
     mock_deps_command,
-    caplog,
 ):
     """Run deps add --candidates when no candidate matches
 
     - mock deps_command to raise DepsNoCandidateError
-    - check the error is reported and the dedicated exit code is used
+    - check the dedicated exit code is used
     """
     action = "add"
     srcname = "check"
-    expected_message = f"No candidate source matched for {srcname}"
-    mock_deps_command.side_effect = project_main.DepsNoCandidateError(
-        expected_message,
-    )
+    mock_deps_command.side_effect = project_main.DepsNoCandidateError
     deps_args = ["deps", action, srcname, "--candidates", "pep735 test"]
 
-    with (
-        caplog.at_level(logging.INFO),
-        pytest.raises(SystemExit) as exc,
-    ):
+    with pytest.raises(SystemExit) as exc:
         project_main.main(deps_args)
     assert exc.value.code == ExitCodes.ADD_NO_CANDIDATE_ERROR
-    assert expected_message in caplog.text
 
 
 def test_deps_cli_add_sources(mock_deps_command):


### PR DESCRIPTION
On `sync --verify` (and `add --sync --verify`), when sources are out of sync, log to stderr the names of the changed sources and the path of the now-synced configuration, in addition to the diff on stdout and the exit code 4.

`add --candidates` likewise reports a failed autodiscovery as an error rather than info: when no candidate source can be collected it logs at error level from the raise site, naming the source and the candidates tried, and the CLI handler only maps the failure to exit code 5 (mirroring the unsynced handler). The exception message itself is unchanged.

Flush stdout at the data-emission points (`_show` and the `eval` loop) so the machine-readable data precedes the diagnostics in a merged stream. Python block-buffers stdout when it is not a terminal (a pipe or file, such as a build log), while stderr is line-buffered; without the flush the buffered stdout data is handed out only at interpreter exit, after the stderr lines, so a merged log would show the diagnostic before the data it refers to. This is documented behavior, not an implementation detail: https://docs.python.org/3/library/sys.html#sys.stderr

Fixes: https://github.com/stanislavlevin/pyproject_installer/issues/171

## Summary by Sourcery

Improve diagnostics and output ordering for dependency sync and autodiscovery commands.

Bug Fixes:
- Ensure machine-readable stdout output is flushed before stderr diagnostics when output is piped, preventing mis-ordered logs.

Enhancements:
- Report unsynced dependency sources as an error-level diagnostic including source names and the synced configuration path.
- Log detailed error information when add --candidates autodiscovery fails, including the source name and candidates tried, and rely on exit codes instead of logging the exception message in the CLI handler.