### PR TITLE
feat(cli): deduplicate repeated list inputs, preserving order

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ python -m pyproject_installer install
 
 > **`--exclude-paths PATTERN [PATTERN ...]`**
 >
-> One or more `fnmatch` glob patterns. Files whose wheel-relative POSIX path matches any pattern are excluded from installation. Pattern syntax follows Python's [`fnmatch`](https://docs.python.org/3/library/fnmatch.html) module: `*` matches any run of characters including `/`; `?` matches one character; `[seq]` / `[!seq]` are character classes.
+> One or more `fnmatch` glob patterns. Files whose wheel-relative POSIX path matches any pattern are excluded from installation. Pattern syntax follows Python's [`fnmatch`](https://docs.python.org/3/library/fnmatch.html) module: `*` matches any run of characters including `/`; `?` matches one character; `[seq]` / `[!seq]` are character classes. Identical patterns are collapsed (first occurrence kept).
 >
 > *Path format:* patterns are matched against the wheel's ZIP `namelist()` entries verbatim. Those entries are always forward-slash separated POSIX paths with no leading `/` and no `./` prefix, regardless of host operating system. Examples of what a pattern matches against: `pkg/__init__.py`, `pkg/sub/foo.py`, `pkg-1.0.dist-info/METADATA`, `pkg-1.0.data/scripts/cli`.
 >
@@ -423,7 +423,7 @@ Show configuration and data of dependencies' sources.
 
 > **`<source names>`** (positional)
 >
-> Source names to show.
+> Source names to show. Repeated names are collapsed (first occurrence kept).
 >
 > *Default:* all
 >
@@ -463,7 +463,7 @@ There are three ways to add sources, exactly one per call:
 
 > **`--candidates LIST`**
 >
-> Discover the source from an ordered list instead of a fixed type. `LIST` is a `;`-separated string whose entries are each `<type> [args ...]` (the same shape as the positional type/args). The walk goes left to right and the first candidate that *collects successfully* (its source is present and collectable) wins, even if it has zero dependencies; its type and args are recorded under the source name. A candidate is skipped when its source cannot be collected (for example a missing file or group); a malformed candidate list (an unknown type or the wrong number of arguments) is an error, not a silent skip. It is mutually exclusive with the positional type/args (giving both is a usage error), so the source name is the only positional; every other aspect of `add` (add-only by default, `--reconfigure`, `--sync` and its verify options) behaves exactly as with an explicit type. Because `--verify-exclude` takes one or more values, keep the source name *before* it.
+> Discover the source from an ordered list instead of a fixed type. `LIST` is a `;`-separated string whose entries are each `<type> [args ...]` (the same shape as the positional type/args). The walk goes left to right and the first candidate that *collects successfully* (its source is present and collectable) wins, even if it has zero dependencies; its type and args are recorded under the source name. A candidate is skipped when its source cannot be collected (for example a missing file or group); a malformed candidate list (an unknown type or the wrong number of arguments) is an error, not a silent skip. Identical entries (same type and args) are collapsed (first occurrence kept). It is mutually exclusive with the positional type/args (giving both is a usage error), so the source name is the only positional; every other aspect of `add` (add-only by default, `--reconfigure`, `--sync` and its verify options) behaves exactly as with an explicit type. Because `--verify-exclude` takes one or more values, keep the source name *before* it.
 >
 > When no candidate is picked, `add` reports it and exits with code 5 in every case, whether or not `name` is already configured and whether or not `--reconfigure` is given; any existing source under `name` is left untouched. `--sync` (and the `--verify` that depends on it) never runs on a no-candidate branch.
 >
@@ -473,7 +473,7 @@ There are three ways to add sources, exactly one per call:
 
 > **`--sources LIST`**
 >
-> Add a batch of explicitly named sources in one call (the additive counterpart of `--candidates`). `LIST` is a `;`-separated string whose entries are each `<name> <type> [args ...]` (a positional `name type [args]` per entry). The entries are handled one at a time, in order: each is configured exactly as a regular `add <name> <type> [args]` (`--reconfigure` applies per entry), and with `--sync` it is synced and verified before the next, so one call equals running `add <name> <type> [args] --reconfigure --sync --verify` once per entry in a single process. A malformed list is a usage error, not a silent skip: an empty list, an entry without a type, an unknown type, or a name repeated within the list; a wrong argument count for a type is reported when that entry is configured (the same error as an explicit `add`).
+> Add a batch of explicitly named sources in one call (the additive counterpart of `--candidates`). `LIST` is a `;`-separated string whose entries are each `<name> <type> [args ...]` (a positional `name type [args]` per entry). The entries are handled one at a time, in order: each is configured exactly as a regular `add <name> <type> [args]` (`--reconfigure` applies per entry), and with `--sync` it is synced and verified before the next, so one call equals running `add <name> <type> [args] --reconfigure --sync --verify` once per entry in a single process. A malformed list is a usage error, not a silent skip: an empty list, an entry without a type, an unknown type, or a name repeated with a different type/args; a wrong argument count for a type is reported when that entry is configured (the same error as an explicit `add`). Identical entries (same name, type and args) are collapsed (first occurrence kept).
 >
 > With `--verify`, the run stops at the first source that is out of sync and exits with code 4; the entries after it are not reached, so a failed run leaves the earlier entries configured and synced and the later ones untouched. Run without `--verify` to configure and sync the whole list in one pass; `--verify` is a check and keeps stopping at the first out-of-sync source. `--sources` takes no positional name/type/args and is mutually exclusive with `--candidates`; because there are no positionals, `--sources` and the verify options may be given in any order.
 >
@@ -557,7 +557,7 @@ Sync stored requirements to configured sources.
 
 > **`<source names>`** (positional)
 >
-> Source names to sync.
+> Source names to sync. Repeated names are collapsed (first occurrence kept).
 >
 > *Default:* all
 >
@@ -573,7 +573,7 @@ Sync stored requirements to configured sources.
 
 > **`--verify-exclude`**
 >
-> Regex patterns; exclude from diff requirements whose PEP 503-normalized names match one of the patterns. Requires `--verify`.
+> Regex patterns; exclude from diff requirements whose PEP 503-normalized names match one of the patterns. Requires `--verify`. Repeated patterns are collapsed (first occurrence kept).
 >
 > *Default:* `[]`
 >
@@ -595,7 +595,7 @@ Evaluate stored requirements according to PEP 508 in current Python environment 
 
 > **`<source names>`** (positional)
 >
-> Source names to evaluate.
+> Source names to evaluate. Repeated names are collapsed (first occurrence kept).
 >
 > *Default:* all
 >
@@ -629,7 +629,7 @@ Evaluate stored requirements according to PEP 508 in current Python environment 
 
 > **`--exclude`**
 >
-> Regex patterns; exclude requirement having PEP 503-normalized name that matches one of these patterns.
+> Regex patterns; exclude requirements whose PEP 503-normalized names match one of these patterns. Repeated patterns are collapsed (first occurrence kept).
 >
 > *Default:* `[]`
 >

--- a/src/pyproject_installer/__main__.py
+++ b/src/pyproject_installer/__main__.py
@@ -247,6 +247,24 @@ def default_built_wheel() -> Path:
     return default_wheel_dir / wheel_filename
 
 
+class DeduplicatingAction(argparse.Action):
+    """Store the option's values with duplicates removed, keeping order."""
+
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,  # noqa: ARG002 (Action signature)
+        namespace: argparse.Namespace,
+        values: str | Sequence[Any] | None,
+        option_string: str | None = None,  # noqa: ARG002 (Action signature)
+    ) -> None:
+        if values is None or isinstance(values, str):
+            raise TypeError(
+                f"{type(self).__name__} expects a list of values from an "
+                f"nargs option, got {values!r}",
+            )
+        setattr(namespace, self.dest, list(dict.fromkeys(values)))
+
+
 def parse_candidates(value: str) -> tuple[tuple[str, ...], ...]:
     """Parse a ;-separated --candidates list into (type, *args) tuples.
 
@@ -256,13 +274,16 @@ def parse_candidates(value: str) -> tuple[tuple[str, ...], ...]:
     ('pep735', 'test') entry). A malformed candidate list is rejected as a
     usage error rather than silently skipped: it is an error when no entries
     are left after dropping blanks (an empty, whitespace-only, or ';'-only
-    value), or when an entry's type is not a known collector.
+    value), or when an entry's type is not a known collector. Identical
+    '<type> [args ...]' entries are collapsed to one (keeping order).
     """
     candidates = tuple(
         tuple(parts) for entry in value.split(";") if (parts := entry.split())
     )
     if not candidates:
         raise argparse.ArgumentTypeError(f"no candidates parsed from {value!r}")
+    # deduplication with preserving order
+    candidates = tuple(dict.fromkeys(candidates))
     for srctype, *_ in candidates:
         if srctype not in SUPPORTED_COLLECTORS:
             raise argparse.ArgumentTypeError(
@@ -282,13 +303,17 @@ def parse_sources(value: str) -> tuple[tuple[str, ...], ...]:
     error when no entries are left after dropping blanks (an empty,
     whitespace-only, or ';'-only value), when an entry has fewer than two
     tokens (a name without a type), when an entry's type is not a known
-    collector, or when a name is repeated within the list.
+    collector, or when entries have the same name but different type/args.
+    Identical '<name> <type> [args ...]' entries are collapsed to one (keeping
+    order).
     """
     sources = tuple(
         tuple(parts) for entry in value.split(";") if (parts := entry.split())
     )
     if not sources:
         raise argparse.ArgumentTypeError(f"no sources parsed from {value!r}")
+    # deduplication with preserving order
+    sources = tuple(dict.fromkeys(sources))
     seen: set[str] = set()
     for srcname, *rest in sources:
         if not rest:
@@ -303,7 +328,8 @@ def parse_sources(value: str) -> tuple[tuple[str, ...], ...]:
             )
         if srcname in seen:
             raise argparse.ArgumentTypeError(
-                f"duplicate source name in a given list: {srcname!r}",
+                f"conflicting source definition for {srcname!r} "
+                "in a given list",
             )
         seen.add(srcname)
     return sources
@@ -397,6 +423,7 @@ def deps_subparsers(parser: argparse.ArgumentParser) -> None:
             dest=destname,
             nargs="+",
             default=[],
+            action=DeduplicatingAction,
             help=(
                 "Regex patterns; exclude from diff requirements whose "
                 "PEP503-normalized names match one of the patterns "
@@ -432,6 +459,7 @@ def deps_subparsers(parser: argparse.ArgumentParser) -> None:
         destname,
         help="source names (default: all)",
         nargs="*",
+        action=DeduplicatingAction,
     )
 
     # sync
@@ -448,6 +476,7 @@ def deps_subparsers(parser: argparse.ArgumentParser) -> None:
         destname,
         help="source names (default: all)",
         nargs="*",
+        action=DeduplicatingAction,
     )
 
     add_sync_options(subparser_sync)
@@ -469,6 +498,7 @@ def deps_subparsers(parser: argparse.ArgumentParser) -> None:
         destname,
         help="source names (default: all)",
         nargs="*",
+        action=DeduplicatingAction,
     )
 
     destname = "depformat"
@@ -513,9 +543,10 @@ def deps_subparsers(parser: argparse.ArgumentParser) -> None:
         dest=destname,
         nargs="+",
         default=[],
+        action=DeduplicatingAction,
         help=(
-            "regexes patterns, exclude requirement having PEP503-normalized "
-            "name that matches one of these patterns (default: [])"
+            "Regex patterns; exclude requirements whose PEP503-normalized "
+            "names match one of these patterns (default: [])"
         ),
     )
 
@@ -792,6 +823,7 @@ def main_parser(prog: str) -> MainArgumentParser:
         dest="exclude_paths",
         nargs="+",
         default=[],
+        action=DeduplicatingAction,
         metavar="PATTERN",
         help=(
             "fnmatch glob patterns. Files whose wheel-relative POSIX path "

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,3 +1,4 @@
+import argparse
 import logging
 import subprocess
 import sys
@@ -100,6 +101,52 @@ def invalid_choice_messages(choice, *, choices):
             ", ".join(f"'{x}'" for x in choices),
         ]
     )
+
+
+@pytest.mark.parametrize(
+    "argv, option",
+    ((["--foo", "x"], "x"), (["--foo"], None)),
+    ids=("str", "none"),
+)
+def test_deduplicating_action_rejects_non_list_values(argv, option):
+    """Check if DeduplicatingAction rejects non multi-value (nargs) options"""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--foo",
+        nargs="?",
+        action=project_main.DeduplicatingAction,
+    )
+    with pytest.raises(
+        TypeError,
+        match=f"expects a list of values from an nargs option, got {option!r}",
+    ):
+        parser.parse_args(argv)
+
+
+def test_deduplicating_action_deduplicates_keeping_order():
+    """DeduplicatingAction collapses repeats in an nargs option, keeps order."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--foo",
+        nargs="+",
+        action=project_main.DeduplicatingAction,
+    )
+
+    args = parser.parse_args(["--foo", "a", "b", "a", "c", "b"])
+    assert args.foo == ["a", "b", "c"]
+
+
+def test_deduplicating_action_allows_empty_list():
+    """An nargs="*" option given with no values is [] -- the Action keeps it."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--foo",
+        nargs="*",
+        action=project_main.DeduplicatingAction,
+    )
+
+    args = parser.parse_args(["--foo"])
+    assert args.foo == []
 
 
 DEFAULT_DEPS_ADD_CLI_KWARGS: dict[str, Any] = {
@@ -612,6 +659,35 @@ def test_install_cli_exclude_paths_multiple(mock_install_wheel):
 
 
 @pytest.mark.usefixtures("mock_read_tracker")
+def test_install_cli_exclude_paths_deduplicated(mock_install_wheel):
+    """
+    Repeated --exclude-paths patterns collapse, first-occurrence order kept.
+    """
+    install_args = [
+        "install",
+        "--exclude-paths",
+        "tests/*",
+        "*/tests/*",
+        "tests/*",
+    ]
+
+    destdir = Path("/")
+    wheel = Path.cwd() / "dist" / "foo.whl"
+    i_args = (wheel,)
+    i_kwargs = {
+        "destdir": destdir,
+        "installer": None,
+        "strip_dist_info": True,
+        "rpm_filelist": None,
+        "force_site": None,
+        "exclude_paths": ["tests/*", "*/tests/*"],
+    }
+
+    project_main.main(install_args)
+    mock_install_wheel.assert_called_once_with(*i_args, **i_kwargs)
+
+
+@pytest.mark.usefixtures("mock_read_tracker")
 def test_install_cli_exclude_paths_single(mock_install_wheel):
     """
     Run install with --exclude-paths passing a single pattern.
@@ -878,6 +954,68 @@ def test_deps_cli_show_selected(mock_deps_command, srcnames):
 
     r_args = (action, Path(depsconfig))
     r_kwargs = {"srcnames": srcnames}
+
+    project_main.main(deps_args)
+    mock_deps_command.assert_called_once_with(*r_args, **r_kwargs)
+
+
+def test_deps_cli_show_srcnames_deduplicated(mock_deps_command):
+    """Run deps show with repeated source names
+
+    - mock deps_command
+    - check duplicates collapse, first-occurrence order preserved
+    """
+    action = "show"
+    depsconfig = Path.cwd() / project_main.DEFAULT_CONFIG_NAME
+    deps_args = ["deps", action, "foo", "bar", "foo", "baz", "bar"]
+
+    r_args = (action, Path(depsconfig))
+    r_kwargs = {"srcnames": ["foo", "bar", "baz"]}
+
+    project_main.main(deps_args)
+    mock_deps_command.assert_called_once_with(*r_args, **r_kwargs)
+
+
+def test_deps_cli_sync_srcnames_deduplicated(mock_deps_command):
+    """Run deps sync with repeated source names
+
+    - mock deps_command
+    - check duplicates collapse, first-occurrence order preserved
+    """
+    action = "sync"
+    depsconfig = Path.cwd() / project_main.DEFAULT_CONFIG_NAME
+    deps_args = ["deps", action, "foo", "bar", "foo", "baz", "bar"]
+
+    r_args = (action, Path(depsconfig))
+    r_kwargs = {
+        "srcnames": ["foo", "bar", "baz"],
+        "verify": False,
+        "verify_excludes": [],
+        "verify_ignore_version": False,
+    }
+
+    project_main.main(deps_args)
+    mock_deps_command.assert_called_once_with(*r_args, **r_kwargs)
+
+
+def test_deps_cli_eval_srcnames_deduplicated(mock_deps_command):
+    """Run deps eval with repeated source names
+
+    - mock deps_command
+    - check duplicates collapse, first-occurrence order preserved
+    """
+    action = "eval"
+    depsconfig = Path.cwd() / project_main.DEFAULT_CONFIG_NAME
+    deps_args = ["deps", action, "foo", "bar", "foo", "baz", "bar"]
+
+    r_args = (action, Path(depsconfig))
+    r_kwargs = {
+        "srcnames": ["foo", "bar", "baz"],
+        "depformat": None,
+        "depformatextra": None,
+        "extra": None,
+        "excludes": [],
+    }
 
     project_main.main(deps_args)
     mock_deps_command.assert_called_once_with(*r_args, **r_kwargs)
@@ -1355,6 +1493,73 @@ def test_deps_cli_sync_verify_excludes(excludes, mock_deps_command):
     mock_deps_command.assert_called_once_with(*r_args, **r_kwargs)
 
 
+def test_deps_cli_sync_verify_excludes_deduplicated(mock_deps_command):
+    """Run deps sync with repeated --verify-exclude patterns
+
+    - mock deps_command
+    - check duplicates collapse, first-occurrence order preserved
+    """
+    action = "sync"
+    depsconfig = Path.cwd() / project_main.DEFAULT_CONFIG_NAME
+    deps_args = [
+        "deps",
+        action,
+        "--verify",
+        "--verify-exclude",
+        "foo",
+        "bar",
+        "foo",
+    ]
+
+    r_args = (action, Path(depsconfig))
+    r_kwargs = {
+        "srcnames": [],
+        "verify": True,
+        "verify_excludes": ["foo", "bar"],
+        "verify_ignore_version": False,
+    }
+
+    project_main.main(deps_args)
+    mock_deps_command.assert_called_once_with(*r_args, **r_kwargs)
+
+
+def test_deps_cli_add_verify_excludes_deduplicated(mock_deps_command):
+    """Run deps add with repeated --verify-exclude patterns
+
+    - mock deps_command
+    - check duplicates collapse, first-occurrence order preserved
+    """
+    action = "add"
+    depsconfig = Path.cwd() / project_main.DEFAULT_CONFIG_NAME
+    srcname = "check"
+    srctype = "metadata"
+    deps_args = [
+        "deps",
+        action,
+        srcname,
+        srctype,
+        "--sync",
+        "--verify",
+        "--verify-exclude",
+        "foo",
+        "bar",
+        "foo",
+    ]
+
+    r_args = (action, Path(depsconfig))
+    r_kwargs = dict(
+        DEFAULT_DEPS_ADD_CLI_KWARGS,
+        srcname=srcname,
+        srctype=srctype,
+        sync=True,
+        verify=True,
+        verify_excludes=["foo", "bar"],
+    )
+
+    project_main.main(deps_args)
+    mock_deps_command.assert_called_once_with(*r_args, **r_kwargs)
+
+
 @pytest.mark.usefixtures("mock_deps_command")
 def test_deps_cli_sync_verify_excludes_without_verify(capsys):
     """Run deps sync with verify_excludes and without verify
@@ -1602,6 +1807,29 @@ def test_deps_cli_eval_extra(mock_deps_command):
         "depformatextra": None,
         "extra": extra,
         "excludes": [],
+    }
+
+    project_main.main(deps_args)
+    mock_deps_command.assert_called_once_with(*r_args, **r_kwargs)
+
+
+def test_deps_cli_eval_exclude_deduplicated(mock_deps_command):
+    """Run deps eval with repeated --exclude patterns
+
+    - mock deps_command
+    - check duplicates collapse, first-occurrence order preserved
+    """
+    action = "eval"
+    depsconfig = Path.cwd() / project_main.DEFAULT_CONFIG_NAME
+    deps_args = ["deps", action, "--exclude", "foo", "bar", "foo"]
+
+    r_args = (action, Path(depsconfig))
+    r_kwargs = {
+        "srcnames": [],
+        "depformat": None,
+        "depformatextra": None,
+        "extra": None,
+        "excludes": ["foo", "bar"],
     }
 
     project_main.main(deps_args)
@@ -2000,6 +2228,64 @@ def test_deps_cli_add_candidates_lenient_parsing(mock_deps_command):
     mock_deps_command.assert_called_once_with(*r_args, **r_kwargs)
 
 
+def test_deps_cli_add_candidates_deduplicated(mock_deps_command):
+    """Run deps add with identical entries repeated in --candidates
+
+    - mock deps_command
+    - identical (type, *args) entries collapse to one, first-occurrence
+      order preserved (first-wins discovery is unaffected)
+    """
+    action = "add"
+    depsconfig = Path.cwd() / project_main.DEFAULT_CONFIG_NAME
+    srcname = "check"
+    deps_args = [
+        "deps",
+        action,
+        srcname,
+        "--candidates",
+        "pep735 test;pip_reqfile r.txt;pep735 test",
+    ]
+
+    r_args = (action, Path(depsconfig))
+    r_kwargs = dict(
+        DEFAULT_DEPS_ADD_CLI_KWARGS,
+        srcname=srcname,
+        candidates=(("pep735", "test"), ("pip_reqfile", "r.txt")),
+    )
+
+    project_main.main(deps_args)
+    mock_deps_command.assert_called_once_with(*r_args, **r_kwargs)
+
+
+def test_deps_cli_add_candidates_same_type_not_deduplicated(mock_deps_command):
+    """Run deps add with the same type but different args in --candidates
+
+    - mock deps_command
+    - entries dedup by the full (type, *args) tuple, so the same type with
+      different args is kept
+    """
+    action = "add"
+    depsconfig = Path.cwd() / project_main.DEFAULT_CONFIG_NAME
+    srcname = "check"
+    deps_args = [
+        "deps",
+        action,
+        srcname,
+        "--candidates",
+        "pep735 test;pep735 other",
+    ]
+
+    r_args = (action, Path(depsconfig))
+    r_kwargs = dict(
+        DEFAULT_DEPS_ADD_CLI_KWARGS,
+        srcname=srcname,
+        candidates=(("pep735", "test"), ("pep735", "other")),
+    )
+
+    project_main.main(deps_args)
+    mock_deps_command.assert_called_once_with(*r_args, **r_kwargs)
+
+
 def test_deps_cli_add_candidates_reconfigure_sync_verify(mock_deps_command):
     """Run deps add --candidates composed with --reconfigure/--sync/--verify
 
@@ -2204,6 +2490,33 @@ def test_deps_cli_add_sources_lenient_parsing(mock_deps_command):
     mock_deps_command.assert_called_once_with(*r_args, **r_kwargs)
 
 
+def test_deps_cli_add_sources_deduplicated(mock_deps_command):
+    """Run deps add with identical entries repeated in --sources
+
+    - mock deps_command
+    - identical (name, type, *args) entries collapse to one, first-occurrence
+      order preserved
+    """
+    action = "add"
+    depsconfig = Path.cwd() / project_main.DEFAULT_CONFIG_NAME
+    deps_args = [
+        "deps",
+        action,
+        "--sources",
+        "a metadata;b pip_reqfile r.txt;a metadata",
+    ]
+
+    r_args = (action, Path(depsconfig))
+    r_kwargs = dict(
+        DEFAULT_DEPS_ADD_CLI_KWARGS,
+        srcname=None,
+        sources=(("a", "metadata"), ("b", "pip_reqfile", "r.txt")),
+    )
+
+    project_main.main(deps_args)
+    mock_deps_command.assert_called_once_with(*r_args, **r_kwargs)
+
+
 def test_deps_cli_add_sources_reconfigure_sync_verify(mock_deps_command):
     """Run deps add --sources composed with --reconfigure/--sync/--verify
 
@@ -2326,18 +2639,22 @@ def test_deps_cli_add_sources_unknown_type_is_error(mock_deps_command, capsys):
     mock_deps_command.assert_not_called()
 
 
-def test_deps_cli_add_sources_duplicate_name_is_error(
+def test_deps_cli_add_sources_conflicting_name_is_error(
     mock_deps_command,
     capsys,
 ):
-    """Run deps add with a name repeated within --sources -> usage error"""
+    """Run deps add --sources with a name repeated with different type/args
+
+    Identical entries collapse, but a name reused with a different type/args
+    is a genuine conflict.
+    """
     action = "add"
     deps_args = ["deps", action, "--sources", "a metadata;a pip_reqfile r.txt"]
 
     with pytest.raises(SystemExit) as exc:
         project_main.main(deps_args)
     assert exc.value.code == ExitCodes.WRONG_USAGE
-    expected_message = "duplicate source name in a given list: 'a'"
+    expected_message = "conflicting source definition for 'a' in a given list"
     assert expected_message in capsys.readouterr().err
     mock_deps_command.assert_not_called()
 


### PR DESCRIPTION
Collapse repeated values in list-shaped CLI inputs (first occurrence kept) on the `pyproject_installer` side, since callers that build these lists programmatically cannot always deduplicate them themselves.

- `DeduplicatingAction` on the `nargs` inputs: `deps show/sync/eval` source names, `eval --exclude, sync/add --verify-exclude`, `install --exclude-paths`. It rejects a single non-list value as a misuse.
- `parse_candidates`/`parse_sources` collapse identical entries; a `--sources` name reused with a different type/args stays a usage error.

Fixes: https://github.com/stanislavlevin/pyproject_installer/issues/173

## Summary by Sourcery

Deduplicate repeated values in list-shaped CLI inputs while preserving first-occurrence order, and align parsing and error handling for candidate and source lists.

New Features:
- Introduce a DeduplicatingAction for nargs-based CLI options to collapse repeated values while preserving order for deps commands and install --exclude-paths.
- Make --candidates and --sources parsing collapse identical entries while preserving order, treating same-name entries with differing type/args as conflicts.

Bug Fixes:
- Treat reused source names with different type/args in --sources as conflicting definitions with a clearer usage error message, addressing incorrect duplicate-name handling.

Documentation:
- Document that list-style options (source names, verify-exclude patterns, exclude patterns, candidates, sources, install exclude-paths) now collapse identical entries, keeping the first occurrence.

Tests:
- Add unit tests covering DeduplicatingAction behavior, including rejection of non-list values and deduplication semantics for deps and install CLI list options, candidates, and sources.